### PR TITLE
feat(cli): add --json-output global flag for JSON output

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -102,6 +102,15 @@ pub struct Cli {
     )]
     pub output_format: OutputFormat,
 
+    /// Format output as JSON (shorthand for --output-format json)
+    #[arg(
+        long = "json-output",
+        visible_alias = "jo",
+        global = true,
+        help_heading = "Display Options"
+    )]
+    pub json_output: bool,
+
     /// Write output to file
     #[arg(
         short = 'o',
@@ -379,6 +388,15 @@ impl Cli {
     /// Check if output should be shown (not quiet)
     pub fn should_show_output(&self) -> bool {
         !self.quiet
+    }
+
+    /// Get the effective output format (--json-output flag overrides --output-format)
+    pub fn effective_output_format(&self) -> OutputFormat {
+        if self.json_output {
+            OutputFormat::Json
+        } else {
+            self.output_format
+        }
     }
 }
 

--- a/cli/src/inspect_command.rs
+++ b/cli/src/inspect_command.rs
@@ -95,7 +95,7 @@ pub fn inspect_command(cli: &Cli, url: &str) -> Result<()> {
 
     let available_methods = config.available_payment_methods();
 
-    match cli.output_format {
+    match cli.effective_output_format() {
         OutputFormat::Json => {
             output_json(cli, &requirements, &available_methods)?;
         }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -9,7 +9,7 @@ use crate::cli::{Cli, OutputFormat};
 
 /// Handle a regular (non-402) HTTP response
 pub fn handle_regular_response(cli: &Cli, response: HttpResponse) -> Result<()> {
-    match cli.output_format {
+    match cli.effective_output_format() {
         OutputFormat::Json => {
             if let Ok(json_value) = serde_json::from_slice::<serde_json::Value>(&response.body) {
                 let output = serde_json::to_string_pretty(&json_value)?;


### PR DESCRIPTION
## Summary

Add `--json-output` (alias: `--jo`) as a global shorthand for `--output-format json`, following Foundry's ergonomic CLI patterns.

## Changes

- New global `--json-output` flag that works across all commands
- Adds `effective_output_format()` helper method to Cli struct
- Updates `output.rs` and `inspect_command.rs` to use the helper

## Usage

```bash
# Before
purl --output-format json https://api.example.com

# After (shorter)
purl --json-output https://api.example.com
purl --jo https://api.example.com
```

## Motivation

Inspired by Foundry's `cast` which uses a simple `--json` flag everywhere. We use `--json-output` because `--json` is already used for sending JSON data in the request body.