### PR TITLE
fix(security): set keystore files to 0600 permissions

### DIFF
--- a/lib/src/keystore/encrypt.rs
+++ b/lib/src/keystore/encrypt.rs
@@ -95,6 +95,13 @@ pub(crate) fn create_keystore_in_dir(
     std::fs::write(&keystore_path, updated_keystore)
         .map_err(|e| PurlError::ConfigMissing(format!("Failed to write keystore: {e}")))?;
 
+    #[cfg(unix)]
+    {
+        use std::fs::Permissions;
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&keystore_path, Permissions::from_mode(0o600))?;
+    }
+
     Ok(keystore_path)
 }
 


### PR DESCRIPTION
## Security Fix

Keystore files were being created with default permissions (0644 on Unix), making them world-readable. This is a security vulnerability as keystore files contain encrypted private keys.

### Changes
- After creating keystore files, explicitly set file permissions to `0600` (owner read/write only) on Unix systems.

### Platform Notes
- Uses `#[cfg(unix)]` to only apply on Unix systems
- Windows file permissions are handled differently and not affected