### PR TITLE
fix(security): add path traversal validation

### DIFF
--- a/cli/src/config_utils.rs
+++ b/cli/src/config_utils.rs
@@ -1,13 +1,17 @@
 //! Configuration loading utilities for the CLI
 
 use anyhow::{Context, Result};
-use purl_lib::{Config, EvmConfig};
+use purl_lib::{validate_path, Config, EvmConfig};
 use std::path::Path;
 
 use crate::cli::Cli;
 
 /// Load configuration from CLI arguments or default location.
 pub fn load_config(config_path: Option<impl AsRef<Path>>) -> Result<Config> {
+    if let Some(ref path) = config_path {
+        let path_str = path.as_ref().to_string_lossy();
+        validate_path(&path_str, true).context("Invalid config path")?;
+    }
     Config::load_from(config_path).context("Failed to load configuration")
 }
 
@@ -21,6 +25,7 @@ pub fn load_config_with_overrides(cli: &Cli) -> Result<Config> {
         });
 
         if let Some(ref keystore) = cli.keystore {
+            validate_path(keystore, true).context("Invalid keystore path")?;
             evm.keystore = Some(keystore.clone().into());
         }
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1,7 +1,7 @@
 //! Output formatting and display utilities for the CLI
 
 use anyhow::{Context, Result};
-use purl_lib::HttpResponse;
+use purl_lib::{validate_path, HttpResponse};
 use serde_json::json;
 use std::path::PathBuf;
 
@@ -47,6 +47,7 @@ pub fn handle_regular_response(cli: &Cli, response: HttpResponse) -> Result<()> 
 /// Write response body to file or stdout
 pub fn output_response_body(cli: &Cli, body: &[u8]) -> Result<()> {
     if let Some(output_file) = &cli.output {
+        validate_path(output_file, true).context("Invalid output path")?;
         std::fs::write(output_file, body).context("Failed to write output file")?;
         if cli.is_verbose() && cli.should_show_output() {
             eprintln!("Saved to: {output_file}");
@@ -66,6 +67,7 @@ pub fn output_response_body(cli: &Cli, body: &[u8]) -> Result<()> {
 pub fn write_output(cli: &Cli, content: impl AsRef<str>) -> Result<()> {
     let content = content.as_ref();
     if let Some(output_file) = &cli.output {
+        validate_path(output_file, true).context("Invalid output path")?;
         std::fs::write(output_file, content).context("Failed to write output file")?;
         if cli.is_verbose() && cli.should_show_output() {
             eprintln!("Saved to: {output_file}");

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -14,6 +14,7 @@ pub mod http;
 pub mod keystore;
 pub mod negotiator;
 pub mod network;
+pub mod path_validation;
 pub mod payment_provider;
 pub mod protocol;
 pub mod providers;
@@ -36,4 +37,5 @@ pub use http::{
 pub use network::{evm_chain_ids, networks, ChainType, GasConfig, Network, NetworkInfo};
 pub use protocol::x402::{PaymentPayload, PaymentRequirementsResponse, SettlementResponse};
 
+pub use path_validation::validate_path;
 pub use payment_provider::{BuiltinProvider, NetworkBalance, PaymentProvider, PROVIDER_REGISTRY};

--- a/lib/src/path_validation.rs
+++ b/lib/src/path_validation.rs
@@ -1,0 +1,87 @@
+//! Path validation utilities to prevent directory traversal attacks.
+
+use std::path::{Component, PathBuf};
+
+use crate::error::PurlError;
+
+/// Validates that a path doesn't contain directory traversal sequences.
+/// Returns the validated path or an error if traversal is detected.
+pub fn validate_path(path: &str, allow_absolute: bool) -> Result<PathBuf, PurlError> {
+    let path = PathBuf::from(path);
+
+    // Check for parent directory components (..)
+    if path.components().any(|c| matches!(c, Component::ParentDir)) {
+        return Err(PurlError::ConfigMissing(
+            "Path traversal (..) not allowed".to_string(),
+        ));
+    }
+
+    // Optionally reject absolute paths
+    if !allow_absolute && path.is_absolute() {
+        return Err(PurlError::ConfigMissing(
+            "Absolute paths not allowed for this option".to_string(),
+        ));
+    }
+
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_relative_path() {
+        let result = validate_path("output.txt", false);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), PathBuf::from("output.txt"));
+    }
+
+    #[test]
+    fn test_valid_nested_relative_path() {
+        let result = validate_path("dir/subdir/file.txt", false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_path_traversal_rejected() {
+        let result = validate_path("../etc/passwd", false);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Path traversal"));
+    }
+
+    #[test]
+    fn test_nested_path_traversal_rejected() {
+        let result = validate_path("foo/../bar/../../etc/passwd", false);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_absolute_path_rejected_when_not_allowed() {
+        let result = validate_path("/etc/passwd", false);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Absolute paths not allowed"));
+    }
+
+    #[test]
+    fn test_absolute_path_allowed_when_specified() {
+        let result = validate_path("/home/user/config.toml", true);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_absolute_path_with_traversal_rejected() {
+        let result = validate_path("/home/user/../etc/passwd", true);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Path traversal"));
+    }
+
+    #[test]
+    fn test_current_dir_allowed() {
+        let result = validate_path("./file.txt", false);
+        assert!(result.is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

Add path validation to prevent directory traversal attacks on user-provided paths.

## Changes

- Added `lib/src/path_validation.rs` with `validate_path()` function that:
  - Rejects paths containing `..` (parent directory) components
  - Optionally rejects absolute paths
  - Returns validated `PathBuf` or `PurlError`

- Applied validation to:
  - `-C` / `--config` path in `cli/src/config_utils.rs`
  - `--keystore` path in `cli/src/config_utils.rs`
  - `-o` / `--output` path in `cli/src/output.rs`

## Security

Prevents attackers from using path traversal sequences like `../../../etc/passwd` to access or write files outside intended directories.