### PR TITLE
docs: add PR link convention to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,22 @@ make run ARGS="<url>"   # Run CLI with arguments
 
 1. ✅ **Check**: `make check` - ZERO issues
 
+## Pull Request Guidelines
+
+When creating pull requests:
+
+1. **Always include the PR link** in your response after creating a PR
+2. Format as a clickable link: `[#123](https://github.com/tempoxyz/purl/pull/123)`
+3. When creating multiple PRs, provide a summary table with all links
+
+Example summary format:
+```
+| PR | Title | Link |
+|----|-------|------|
+| 1 | feat: add feature X | [#123](https://github.com/tempoxyz/purl/pull/123) |
+| 2 | fix: resolve issue Y | [#124](https://github.com/tempoxyz/purl/pull/124) |
+```
+
 ## Code Style Guidelines
 
 ### Rust Conventions


### PR DESCRIPTION
## Summary

Add a section to AGENTS.md requiring that AI agents always include clickable PR links when creating pull requests.

## Changes

- Added "Pull Request Guidelines" section
- Requires PR links in format `[#123](url)`
- Includes example summary table format for multiple PRs

This ensures users can easily navigate to created PRs.