### PR TITLE
add ast-grep to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,12 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+      - name: Install ast-grep
+        run: npm install -g @ast-grep/cli
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace -- -D warnings
+      - name: Run ast-grep lint
+        run: ast-grep scan --config sgconfig.yml
 
   test:
     name: Test (${{ matrix.os }})

--- a/lib/src/protocol/web/encode.rs
+++ b/lib/src/protocol/web/encode.rs
@@ -213,10 +213,12 @@ mod tests {
             intent: PaymentIntent::Charge,
             request: serde_json::json!({"amount": "10000"}),
             expires: None,
+            // ast-grep-ignore: no-leading-whitespace-strings
             description: Some("Test \"payment\" here".to_string()),
         };
 
         let header = format_www_authenticate(&challenge).unwrap();
+        // ast-grep-ignore: no-leading-whitespace-strings
         assert!(header.contains("description=\"Test \\\"payment\\\" here\""));
     }
 }

--- a/lib/src/protocol/web/parse.rs
+++ b/lib/src/protocol/web/parse.rs
@@ -184,12 +184,14 @@ mod tests {
             intent: PaymentIntent::Authorize,
             request: serde_json::json!({}),
             expires: None,
+            // ast-grep-ignore: no-leading-whitespace-strings
             description: Some("Test \"quoted\" text".to_string()),
         };
 
         let header = format_www_authenticate(&challenge).unwrap();
         let parsed = parse_www_authenticate(&header).unwrap();
 
+        // ast-grep-ignore: no-leading-whitespace-strings
         assert_eq!(parsed.description, Some("Test \"quoted\" text".to_string()));
     }
 

--- a/lib/src/protocol/web/types.rs
+++ b/lib/src/protocol/web/types.rs
@@ -444,7 +444,8 @@ mod tests {
             Some(PaymentProtocol::WebPaymentAuth)
         );
         assert_eq!(
-            PaymentProtocol::detect(Some("\t Payment id=\"abc\"")),
+            // ast-grep-ignore: no-leading-whitespace-strings
+            PaymentProtocol::detect(Some("\t Payment id=\"abc\"")), // Intentional: testing whitespace tolerance
             Some(PaymentProtocol::WebPaymentAuth)
         );
 

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -60,7 +60,8 @@ mod tests {
         assert_eq!(strip_0x_prefix("0xabc123"), "abc123");
         assert_eq!(strip_0x_prefix("0Xabc123"), "abc123");
         assert_eq!(strip_0x_prefix("abc123"), "abc123");
-        assert_eq!(strip_0x_prefix(" 0xabc123 "), "abc123");
+        // ast-grep-ignore: no-leading-whitespace-strings
+        assert_eq!(strip_0x_prefix(" 0xabc123 "), "abc123"); // Intentional: testing whitespace trimming
     }
 
     #[test]

--- a/rules/lint/no-emojis.yml
+++ b/rules/lint/no-emojis.yml
@@ -5,13 +5,21 @@ language: rust
 note: |
   Emojis can cause issues with terminal rendering, log parsing, and accessibility.
   If you need to use emojis, add the file to the allowlist in this rule.
-  
+
   To disable this rule:
   - Line: add `// ast-grep-ignore: no-emojis` on the line before
   - Block: wrap code with `// ast-grep-ignore-start` and `// ast-grep-ignore-end`
 rule:
   kind: string_content
+  pattern: $CONTENT
   regex: "[\U0001F300-\U0001F9FF\U00002600-\U000026FF\U00002700-\U000027BF\U0001F600-\U0001F64F\U0001F680-\U0001F6FF]"
+fix: $CLEANED
+transform:
+  CLEANED:
+    replace:
+      source: $CONTENT
+      replace: "[\U0001F300-\U0001F9FF\U00002600-\U000026FF\U00002700-\U000027BF\U0001F600-\U0001F64F\U0001F680-\U0001F6FF]\\s?"
+      by: ""
 files:
   - "**/*.rs"
 ignores:

--- a/rules/lint/no-leading-whitespace-strings.yml
+++ b/rules/lint/no-leading-whitespace-strings.yml
@@ -5,13 +5,13 @@ language: rust
 note: |
   Strings that start with a single space followed by text like " foo" are often 
   unintentional typos and can cause display issues.
-  
+
   This rule ignores:
   - Multi-line string indentation (2+ spaces or tabs)
   - Format strings with placeholders
-  
+
   If intentional, disable with `// ast-grep-ignore: no-leading-whitespace-strings`
-  
+
   To disable this rule:
   - Line: add `// ast-grep-ignore: no-leading-whitespace-strings` on the line before
   - Block: wrap code with `// ast-grep-ignore-start` and `// ast-grep-ignore-end`
@@ -19,3 +19,9 @@ rule:
   kind: string_content
   pattern: $CONTENT
   regex: "^ [^\\s{]"
+fix: $TRIMMED
+transform:
+  TRIMMED:
+    substring:
+      source: $CONTENT
+      startChar: 1

--- a/rules/tests/__snapshots__/no-emojis-snapshot.yml
+++ b/rules/tests/__snapshots__/no-emojis-snapshot.yml
@@ -2,21 +2,27 @@ id: no-emojis
 snapshots:
   ? |
     let emoji = "🎉";
-  : labels:
+  : fixed: |
+      let emoji = "";
+    labels:
     - source: 🎉
       style: primary
       start: 13
       end: 17
   ? |
     let status = "✅ Complete";
-  : labels:
+  : fixed: |
+      let status = "Complete";
+    labels:
     - source: ✅ Complete
       style: primary
       start: 14
       end: 26
   ? |
     println!("Done! 🚀");
-  : labels:
+  : fixed: |
+      println!("Done! ");
+    labels:
     - source: Done! 🚀
       style: primary
       start: 10

--- a/rules/tests/__snapshots__/no-leading-whitespace-strings-snapshot.yml
+++ b/rules/tests/__snapshots__/no-leading-whitespace-strings-snapshot.yml
@@ -2,14 +2,18 @@ id: no-leading-whitespace-strings
 snapshots:
   ? |
     let bad = " bar";
-  : labels:
+  : fixed: |
+      let bad = "bar";
+    labels:
     - source: ' bar'
       style: primary
       start: 11
       end: 15
   ? |
     let padded = " foo";
-  : labels:
+  : fixed: |
+      let padded = "foo";
+    labels:
     - source: ' foo'
       style: primary
       start: 14


### PR DESCRIPTION
## Context

Adds ast-grep to CI, so that violations are caught. 

We don't push back fixes at this point, but callers can fix locally by calling `make ast-fix`