### PR TITLE
feat: add pluggable HTTP middleware for Tower and reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,16 @@ rpassword = "7.4"
 tokio = { version = "1.49", features = ["full"] }
 async-trait = "0.1"
 
+# Tower middleware
+tower = "0.5"
+tower-service = "0.3"
+http = "1.2"
+http-body = "1.0"
+http-body-util = "0.1"
+pin-project-lite = "0.2"
+
+# Reqwest middleware
+reqwest-middleware = "0.4"
+
 # Tempo transaction types (used for Tempo network support)
 tempo-primitives = { git = "https://github.com/tempoxyz/tempo.git", rev = "07dfcd2d2b8c109d6b8502515c7db00198a8b3a3", features = ["serde"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -48,6 +48,15 @@ evm = [
 # Full featured (all functionality)
 full = ["evm", "client", "keystore", "http-client", "config", "blocking"]
 
+# Tower middleware (hyper, axum, tonic, etc.)
+tower-middleware = ["dep:tower", "dep:tower-service", "dep:http", "dep:http-body", "dep:http-body-util", "dep:pin-project-lite", "runtime", "web-payment-auth", "evm", "config", "keystore"]
+
+# Reqwest middleware (reqwest-middleware crate)
+reqwest-middleware = ["dep:reqwest-middleware", "dep:http", "http-client", "web-payment-auth", "evm", "config", "keystore"]
+
+# All middleware features
+middleware = ["tower-middleware", "reqwest-middleware"]
+
 [dependencies]
 # Core dependencies (minimal - only for protocol and error types)
 serde.workspace = true
@@ -82,6 +91,17 @@ alloy = { workspace = true, optional = true }
 alloy-signer-local = { workspace = true, optional = true }
 eth-keystore = { workspace = true, optional = true }
 tempo-primitives = { workspace = true, optional = true }
+
+# Tower middleware
+tower = { workspace = true, optional = true }
+tower-service = { workspace = true, optional = true }
+http = { workspace = true, optional = true }
+http-body = { workspace = true, optional = true }
+http-body-util = { workspace = true, optional = true }
+pin-project-lite = { workspace = true, optional = true }
+
+# Reqwest middleware
+reqwest-middleware = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -175,6 +175,25 @@ impl WalletConfig for EvmConfig {
 }
 
 impl Config {
+    /// Create a new ConfigBuilder for programmatic configuration.
+    ///
+    /// This is useful when you want to create a configuration in code
+    /// rather than loading it from a file.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use purl::Config;
+    ///
+    /// let config = Config::builder()
+    ///     .evm_private_key("your_private_key_here")
+    ///     .rpc_override("base", "https://my-rpc.com")
+    ///     .build();
+    /// ```
+    pub fn builder() -> ConfigBuilder {
+        ConfigBuilder::new()
+    }
+
     /// Load config from the specified path or default location (~/.purl/config.toml)
     pub fn load_from(config_path: Option<impl AsRef<Path>>) -> Result<Self> {
         let config_path = if let Some(path) = config_path {
@@ -338,6 +357,175 @@ impl PaymentMethod {
 impl fmt::Display for PaymentMethod {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.display_name())
+    }
+}
+
+/// Builder for creating [`Config`] programmatically.
+///
+/// This builder provides a fluent API for creating configuration in code,
+/// which is useful for SDK users who don't want to use config files.
+///
+/// # Example
+///
+/// ```
+/// use purl::ConfigBuilder;
+///
+/// let config = ConfigBuilder::new()
+///     .evm_private_key("your_private_key_here")
+///     .rpc_override("base", "https://my-custom-rpc.com")
+///     .rpc_override("ethereum", "https://eth-mainnet.example.com")
+///     .build();
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct ConfigBuilder {
+    evm_keystore: Option<PathBuf>,
+    evm_private_key: Option<String>,
+    rpc_overrides: HashMap<String, String>,
+    custom_networks: Vec<CustomNetwork>,
+    custom_tokens: Vec<CustomToken>,
+}
+
+impl ConfigBuilder {
+    /// Create a new empty ConfigBuilder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the path to an EVM keystore file.
+    ///
+    /// This is mutually exclusive with `evm_private_key`.
+    #[must_use]
+    pub fn evm_keystore(mut self, path: impl Into<PathBuf>) -> Self {
+        self.evm_keystore = Some(path.into());
+        self
+    }
+
+    /// Set the EVM private key directly.
+    ///
+    /// This is mutually exclusive with `evm_keystore`.
+    ///
+    /// # Security Note
+    ///
+    /// Using a private key directly is less secure than using a keystore.
+    /// Only use this for testing or when the key is already in memory.
+    #[must_use]
+    pub fn evm_private_key(mut self, key: impl Into<String>) -> Self {
+        self.evm_private_key = Some(key.into());
+        self
+    }
+
+    /// Add an RPC URL override for a network.
+    ///
+    /// This overrides the default RPC URL for the specified network.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use purl::ConfigBuilder;
+    ///
+    /// let config = ConfigBuilder::new()
+    ///     .evm_private_key("test_key")
+    ///     .rpc_override("base", "https://my-base-rpc.com")
+    ///     .build();
+    /// ```
+    #[must_use]
+    pub fn rpc_override(mut self, network: impl Into<String>, url: impl Into<String>) -> Self {
+        self.rpc_overrides.insert(network.into(), url.into());
+        self
+    }
+
+    /// Add a custom network definition.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use purl::{ConfigBuilder, CustomNetwork};
+    /// use purl::network::ChainType;
+    ///
+    /// let network = CustomNetwork {
+    ///     id: "my-chain".to_string(),
+    ///     chain_type: ChainType::Evm,
+    ///     chain_id: Some(12345),
+    ///     mainnet: false,
+    ///     display_name: "My Custom Chain".to_string(),
+    ///     rpc_url: "https://rpc.mychain.com".to_string(),
+    /// };
+    ///
+    /// let config = ConfigBuilder::new()
+    ///     .evm_private_key("test_key")
+    ///     .custom_network(network)
+    ///     .build();
+    /// ```
+    #[must_use]
+    pub fn custom_network(mut self, network: CustomNetwork) -> Self {
+        self.custom_networks.push(network);
+        self
+    }
+
+    /// Add a custom token definition.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use purl::{ConfigBuilder, CustomToken};
+    ///
+    /// let token = CustomToken {
+    ///     network: "ethereum".to_string(),
+    ///     address: "0x1234567890123456789012345678901234567890".to_string(),
+    ///     symbol: "TEST".to_string(),
+    ///     name: "Test Token".to_string(),
+    ///     decimals: 18,
+    /// };
+    ///
+    /// let config = ConfigBuilder::new()
+    ///     .evm_private_key("test_key")
+    ///     .custom_token(token)
+    ///     .build();
+    /// ```
+    #[must_use]
+    pub fn custom_token(mut self, token: CustomToken) -> Self {
+        self.custom_tokens.push(token);
+        self
+    }
+
+    /// Build the [`Config`].
+    ///
+    /// This creates a Config from the builder's settings. Note that the
+    /// resulting Config may not pass validation if no wallet is configured.
+    pub fn build(self) -> Config {
+        let evm = if self.evm_keystore.is_some() || self.evm_private_key.is_some() {
+            Some(EvmConfig {
+                keystore: self.evm_keystore,
+                private_key: self.evm_private_key,
+            })
+        } else {
+            None
+        };
+
+        Config {
+            evm,
+            rpc: self.rpc_overrides,
+            networks: self.custom_networks,
+            tokens: self.custom_tokens,
+        }
+    }
+
+    /// Build and validate the [`Config`].
+    ///
+    /// This creates a Config from the builder's settings and validates it.
+    /// Returns an error if the configuration is invalid (e.g., no wallet configured).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Both keystore and private_key are set
+    /// - Neither keystore nor private_key is set
+    /// - The keystore path doesn't exist
+    /// - The private key format is invalid
+    pub fn build_validated(self) -> Result<Config> {
+        let config = self.build();
+        config.validate()?;
+        Ok(config)
     }
 }
 

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -181,6 +181,7 @@ pub enum PurlError {
     Io(#[from] std::io::Error),
 
     /// Reqwest error
+    #[cfg(feature = "http-client")]
     #[error("HTTP request error: {0}")]
     Reqwest(#[from] reqwest::Error),
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -9,11 +9,14 @@
 //! - `runtime`: Async runtime support (tokio, async-trait)
 //! - `utils`: Encoding and utility functions (bs58, hex, base64, rand)
 //! - `config`: Configuration file support (toml, regex)
-//! - `http-client`: HTTP client using curl
+//! - `http-client`: HTTP client using reqwest
 //! - `client`: High-level Client API (requires http-client and web-payment-auth)
 //! - `keystore`: Encrypted keystore management
 //! - `evm`: EVM provider support (Ethereum, Base, etc.)
 //! - `full`: All features enabled
+//! - `tower-middleware`: Tower middleware for hyper, axum, tonic, etc.
+//! - `reqwest-middleware`: Reqwest middleware integration
+//! - `middleware`: All middleware features
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -42,7 +45,12 @@ pub mod providers;
 #[cfg(feature = "client")]
 pub mod client;
 
-pub use config::Config;
+#[cfg(any(feature = "tower-middleware", feature = "reqwest-middleware"))]
+pub mod middleware;
+
+pub mod prelude;
+
+pub use config::{Config, ConfigBuilder};
 pub use error::{PurlError, Result, ResultExt, SigningContext};
 
 pub use config::{CustomNetwork, CustomToken, EvmConfig, PaymentMethod, WalletConfig};
@@ -60,7 +68,7 @@ pub use types::TokenAmount;
 pub use alloy::primitives::{Address, U256};
 
 #[cfg(feature = "client")]
-pub use client::{Client, ClientBuilder, Configured, Unconfigured};
+pub use client::{Client, ClientBuilder, Configured, PaymentResult, Unconfigured};
 
 #[cfg(feature = "http-client")]
 pub use http::{
@@ -69,3 +77,13 @@ pub use http::{
 
 #[cfg(feature = "blocking")]
 pub use http::blocking;
+
+// Middleware exports
+#[cfg(any(feature = "tower-middleware", feature = "reqwest-middleware"))]
+pub use middleware::{PaymentHandler, PaymentHandlerConfig};
+
+#[cfg(feature = "tower-middleware")]
+pub use middleware::{PaymentLayer, PaymentService};
+
+#[cfg(feature = "reqwest-middleware")]
+pub use middleware::PaymentMiddleware;

--- a/lib/src/middleware/core.rs
+++ b/lib/src/middleware/core.rs
@@ -1,0 +1,337 @@
+//! Core payment handler logic for middleware implementations.
+//!
+//! This module provides HTTP-client-agnostic payment handling that can be used
+//! by various middleware implementations (Tower, reqwest-middleware, etc.).
+
+use std::sync::Arc;
+
+use crate::config::Config;
+use crate::error::{PurlError, Result};
+use crate::payment_provider::PROVIDER_REGISTRY;
+use crate::protocol::web::{
+    format_authorization, parse_www_authenticate, ChargeRequest, PaymentChallenge,
+    PaymentCredential, PaymentProtocol, WWW_AUTHENTICATE_HEADER,
+};
+
+/// Configuration for payment handler middleware.
+///
+/// This configuration controls how payment challenges are validated and processed.
+#[derive(Debug, Clone)]
+pub struct PaymentHandlerConfig {
+    /// Purl configuration containing wallet and network settings.
+    pub config: Arc<Config>,
+
+    /// Maximum amount (in token base units) willing to pay.
+    ///
+    /// If a payment request exceeds this amount, the handler will return an error.
+    pub max_amount: Option<String>,
+
+    /// Networks to allow for payments.
+    ///
+    /// If non-empty, only payment challenges for these networks will be processed.
+    /// Empty means all supported networks are allowed.
+    pub allowed_networks: Vec<String>,
+
+    /// Enable dry-run mode.
+    ///
+    /// In dry-run mode, challenges are validated but no actual payments are made.
+    pub dry_run: bool,
+}
+
+impl PaymentHandlerConfig {
+    /// Create a new payment handler configuration.
+    pub fn new(config: Config) -> Self {
+        Self {
+            config: Arc::new(config),
+            max_amount: None,
+            allowed_networks: Vec::new(),
+            dry_run: false,
+        }
+    }
+
+    /// Set the maximum amount willing to pay.
+    #[must_use]
+    pub fn max_amount(mut self, amount: impl Into<String>) -> Self {
+        self.max_amount = Some(amount.into());
+        self
+    }
+
+    /// Restrict payments to only these networks.
+    #[must_use]
+    pub fn allowed_networks(mut self, networks: &[&str]) -> Self {
+        self.allowed_networks = networks.iter().map(|s| s.to_string()).collect();
+        self
+    }
+
+    /// Enable or disable dry-run mode.
+    #[must_use]
+    pub fn dry_run(mut self, dry_run: bool) -> Self {
+        self.dry_run = dry_run;
+        self
+    }
+}
+
+/// HTTP-client-agnostic payment handler.
+///
+/// This handler provides the core payment processing logic that can be used
+/// by various middleware implementations. It handles:
+///
+/// - Detecting payment requirements from HTTP status codes and headers
+/// - Parsing payment challenges from WWW-Authenticate headers
+/// - Validating challenges against configured limits
+/// - Creating payment credentials using the appropriate provider
+/// - Formatting Authorization headers for retry requests
+///
+/// # Example
+///
+/// ```ignore
+/// use purl::middleware::{PaymentHandler, PaymentHandlerConfig};
+///
+/// let config = purl::Config::load()?;
+/// let handler = PaymentHandler::new(PaymentHandlerConfig::new(config)
+///     .max_amount("1000000")
+///     .allowed_networks(&["base", "tempo"]));
+///
+/// // Check if response requires payment
+/// if handler.requires_payment(status_code) {
+///     // Parse the challenge
+///     let challenge = handler.parse_challenge(www_auth_header)?;
+///
+///     // Validate against our limits
+///     handler.validate_challenge(&challenge)?;
+///
+///     // Create payment credential
+///     let credential = handler.create_credential(&challenge).await?;
+///
+///     // Format the Authorization header
+///     let auth_header = handler.format_authorization(&credential)?;
+///
+///     // Retry request with auth_header...
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub struct PaymentHandler {
+    config: PaymentHandlerConfig,
+}
+
+impl PaymentHandler {
+    /// Create a new payment handler with the given configuration.
+    pub fn new(config: PaymentHandlerConfig) -> Self {
+        Self { config }
+    }
+
+    /// Check if the HTTP status code indicates a payment is required.
+    ///
+    /// Returns `true` for HTTP 402 Payment Required status.
+    #[inline]
+    pub fn requires_payment(&self, status: u16) -> bool {
+        status == 402
+    }
+
+    /// Check if the WWW-Authenticate header indicates Web Payment Auth protocol.
+    ///
+    /// Returns `true` if the header starts with "Payment " (case-insensitive).
+    pub fn is_payment_challenge(&self, www_authenticate: Option<&str>) -> bool {
+        PaymentProtocol::detect(www_authenticate).is_some()
+    }
+
+    /// Parse a payment challenge from a WWW-Authenticate header value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the header is malformed or missing required fields.
+    pub fn parse_challenge(&self, www_authenticate: &str) -> Result<PaymentChallenge> {
+        parse_www_authenticate(www_authenticate)
+    }
+
+    /// Validate a payment challenge against the handler's configuration.
+    ///
+    /// This validates:
+    /// - The payment method is supported
+    /// - The payment intent is supported (only 'charge' currently)
+    /// - The network is in the allowed networks list (if configured)
+    /// - The amount does not exceed the maximum (if configured)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any validation fails.
+    pub fn validate_challenge(&self, challenge: &PaymentChallenge) -> Result<()> {
+        // Validate basic challenge requirements
+        challenge.validate()?;
+
+        // Get the network name
+        let network_name = challenge.network_name()?;
+
+        // Check allowed networks
+        if !self.config.allowed_networks.is_empty()
+            && !self
+                .config
+                .allowed_networks
+                .contains(&network_name.to_string())
+        {
+            return Err(PurlError::NoCompatibleMethod {
+                networks: vec![network_name.to_string()],
+            });
+        }
+
+        // Validate amount if max is configured
+        if let Some(ref max_amount) = self.config.max_amount {
+            let charge_req: ChargeRequest = serde_json::from_value(challenge.request.clone())
+                .map_err(|e| {
+                    PurlError::InvalidChallenge(format!("Invalid charge request: {}", e))
+                })?;
+
+            charge_req.validate_max_amount(max_amount)?;
+        }
+
+        Ok(())
+    }
+
+    /// Create a payment credential for the given challenge.
+    ///
+    /// This uses the appropriate payment provider based on the challenge's
+    /// payment method to sign the payment transaction.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - No provider is found for the network
+    /// - The payment cannot be created (signing fails, etc.)
+    pub async fn create_credential(
+        &self,
+        challenge: &PaymentChallenge,
+    ) -> Result<PaymentCredential> {
+        if self.config.dry_run {
+            return Err(PurlError::InvalidChallenge(
+                "Cannot create credential in dry-run mode".to_string(),
+            ));
+        }
+
+        let network_name = challenge.network_name()?;
+
+        let provider = PROVIDER_REGISTRY
+            .find_provider(network_name)
+            .ok_or_else(|| PurlError::ProviderNotFound(network_name.to_string()))?;
+
+        provider
+            .create_web_payment(challenge, &self.config.config)
+            .await
+    }
+
+    /// Format a payment credential as an Authorization header value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the credential cannot be encoded.
+    pub fn format_authorization(&self, credential: &PaymentCredential) -> Result<String> {
+        format_authorization(credential)
+    }
+
+    /// Get the underlying configuration.
+    pub fn config(&self) -> &PaymentHandlerConfig {
+        &self.config
+    }
+
+    /// Check if dry-run mode is enabled.
+    pub fn is_dry_run(&self) -> bool {
+        self.config.dry_run
+    }
+
+    /// Get the WWW-Authenticate header name (lowercase).
+    pub fn www_authenticate_header() -> &'static str {
+        WWW_AUTHENTICATE_HEADER
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::EvmConfig;
+
+    /// Test EVM private key (DO NOT use in production)
+    const TEST_EVM_KEY: &str = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+
+    fn test_config() -> Config {
+        Config {
+            evm: Some(EvmConfig {
+                keystore: None,
+                private_key: Some(TEST_EVM_KEY.to_string()),
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_payment_handler_config_new() {
+        let config = test_config();
+        let handler_config = PaymentHandlerConfig::new(config);
+
+        assert!(handler_config.max_amount.is_none());
+        assert!(handler_config.allowed_networks.is_empty());
+        assert!(!handler_config.dry_run);
+    }
+
+    #[test]
+    fn test_payment_handler_config_builder() {
+        let config = test_config();
+        let handler_config = PaymentHandlerConfig::new(config)
+            .max_amount("1000000")
+            .allowed_networks(&["base", "tempo"])
+            .dry_run(true);
+
+        assert_eq!(handler_config.max_amount, Some("1000000".to_string()));
+        assert_eq!(handler_config.allowed_networks.len(), 2);
+        assert!(handler_config
+            .allowed_networks
+            .contains(&"base".to_string()));
+        assert!(handler_config
+            .allowed_networks
+            .contains(&"tempo".to_string()));
+        assert!(handler_config.dry_run);
+    }
+
+    #[test]
+    fn test_payment_handler_requires_payment() {
+        let config = test_config();
+        let handler = PaymentHandler::new(PaymentHandlerConfig::new(config));
+
+        assert!(handler.requires_payment(402));
+        assert!(!handler.requires_payment(200));
+        assert!(!handler.requires_payment(401));
+        assert!(!handler.requires_payment(403));
+        assert!(!handler.requires_payment(404));
+        assert!(!handler.requires_payment(500));
+    }
+
+    #[test]
+    fn test_payment_handler_is_payment_challenge() {
+        let config = test_config();
+        let handler = PaymentHandler::new(PaymentHandlerConfig::new(config));
+
+        assert!(handler.is_payment_challenge(Some("Payment id=\"abc\"")));
+        assert!(handler.is_payment_challenge(Some("payment id=\"abc\"")));
+        assert!(handler.is_payment_challenge(Some("PAYMENT id=\"abc\"")));
+        assert!(!handler.is_payment_challenge(Some("Bearer token")));
+        assert!(!handler.is_payment_challenge(Some("Basic dXNlcjpwYXNz")));
+        assert!(!handler.is_payment_challenge(None));
+    }
+
+    #[test]
+    fn test_payment_handler_is_dry_run() {
+        let config = test_config();
+
+        let handler = PaymentHandler::new(PaymentHandlerConfig::new(config.clone()).dry_run(true));
+        assert!(handler.is_dry_run());
+
+        let handler = PaymentHandler::new(PaymentHandlerConfig::new(config).dry_run(false));
+        assert!(!handler.is_dry_run());
+    }
+
+    #[test]
+    fn test_www_authenticate_header() {
+        assert_eq!(
+            PaymentHandler::www_authenticate_header(),
+            "www-authenticate"
+        );
+    }
+}

--- a/lib/src/middleware/mod.rs
+++ b/lib/src/middleware/mod.rs
@@ -1,0 +1,59 @@
+//! HTTP middleware for payment handling.
+//!
+//! This module provides middleware implementations that can be plugged into
+//! various HTTP client ecosystems to automatically handle 402 Payment Required
+//! responses using the Web Payment Auth protocol.
+//!
+//! # Available Middleware
+//!
+//! - **Tower**: `PaymentLayer` and `PaymentService` for hyper, axum, tonic, etc.
+//!   (requires `tower-middleware` feature)
+//! - **Reqwest**: `PaymentMiddleware` for reqwest-middleware crate
+//!   (requires `reqwest-middleware` feature)
+//!
+//! # Core Types
+//!
+//! All middleware implementations are built on [`PaymentHandler`], which provides
+//! HTTP-client-agnostic payment handling logic.
+//!
+//! # Examples
+//!
+//! ## Tower Middleware
+//!
+//! ```ignore
+//! use purl::middleware::{PaymentLayer, PaymentHandlerConfig};
+//! use tower::ServiceBuilder;
+//!
+//! let config = purl::Config::load()?;
+//! let service = ServiceBuilder::new()
+//!     .layer(PaymentLayer::new(config).max_amount("1000000"))
+//!     .service(hyper_client);
+//! ```
+//!
+//! ## Reqwest Middleware
+//!
+//! ```ignore
+//! use purl::middleware::PaymentMiddleware;
+//! use reqwest_middleware::ClientBuilder;
+//!
+//! let config = purl::Config::load()?;
+//! let client = ClientBuilder::new(reqwest::Client::new())
+//!     .with(PaymentMiddleware::new(config))
+//!     .build();
+//! ```
+
+mod core;
+
+#[cfg(feature = "tower-middleware")]
+pub mod tower;
+
+#[cfg(feature = "reqwest-middleware")]
+pub mod reqwest_mw;
+
+pub use self::core::{PaymentHandler, PaymentHandlerConfig};
+
+#[cfg(feature = "tower-middleware")]
+pub use self::tower::{PaymentLayer, PaymentService};
+
+#[cfg(feature = "reqwest-middleware")]
+pub use self::reqwest_mw::PaymentMiddleware;

--- a/lib/src/middleware/reqwest_mw.rs
+++ b/lib/src/middleware/reqwest_mw.rs
@@ -1,0 +1,267 @@
+//! Reqwest middleware for automatic payment handling.
+//!
+//! This module provides a middleware implementation for the `reqwest-middleware`
+//! crate that automatically handles HTTP 402 Payment Required responses using
+//! the Web Payment Auth protocol.
+//!
+//! # Overview
+//!
+//! The reqwest middleware integrates with the `reqwest-middleware` ecosystem,
+//! allowing you to add payment handling to reqwest clients through the
+//! middleware pattern.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use purl::middleware::{PaymentMiddleware, PaymentHandlerConfig};
+//! use reqwest_middleware::ClientBuilder;
+//!
+//! let config = purl::Config::load()?;
+//! let payment_config = PaymentHandlerConfig::new(config)
+//!     .max_amount("1000000")
+//!     .allowed_networks(&["base", "tempo"]);
+//!
+//! let client = ClientBuilder::new(reqwest::Client::new())
+//!     .with(PaymentMiddleware::new(payment_config))
+//!     .build();
+//!
+//! // Now all requests through `client` will automatically handle 402 responses
+//! let response = client.get("https://api.example.com/paid-resource")
+//!     .send()
+//!     .await?;
+//! ```
+
+use std::sync::Arc;
+
+use reqwest::{Request, Response};
+use reqwest_middleware::{Middleware, Next};
+
+use super::{PaymentHandler, PaymentHandlerConfig};
+use crate::config::Config;
+use crate::error::PurlError;
+use crate::protocol::web::AUTHORIZATION_HEADER;
+
+/// Reqwest middleware that handles payment-required responses.
+///
+/// This middleware intercepts 402 Payment Required responses and automatically
+/// negotiates and submits payments before retrying the request.
+///
+/// # Example
+///
+/// ```ignore
+/// use purl::middleware::{PaymentMiddleware, PaymentHandlerConfig};
+/// use reqwest_middleware::ClientBuilder;
+///
+/// let config = purl::Config::load()?;
+/// let client = ClientBuilder::new(reqwest::Client::new())
+///     .with(PaymentMiddleware::new(PaymentHandlerConfig::new(config)))
+///     .build();
+/// ```
+#[derive(Debug, Clone)]
+pub struct PaymentMiddleware {
+    handler: Arc<PaymentHandler>,
+}
+
+impl PaymentMiddleware {
+    /// Create a new payment middleware with the given configuration.
+    pub fn new(config: PaymentHandlerConfig) -> Self {
+        Self {
+            handler: Arc::new(PaymentHandler::new(config)),
+        }
+    }
+
+    /// Create a new payment middleware from a purl Config.
+    ///
+    /// This is a convenience method that creates a default `PaymentHandlerConfig`.
+    pub fn from_config(config: Config) -> Self {
+        Self::new(PaymentHandlerConfig::new(config))
+    }
+
+    /// Set the maximum amount willing to pay.
+    #[must_use]
+    pub fn max_amount(self, amount: impl Into<String>) -> Self {
+        Self {
+            handler: Arc::new(PaymentHandler::new(
+                self.handler.config().clone().max_amount(amount),
+            )),
+        }
+    }
+
+    /// Restrict payments to only these networks.
+    #[must_use]
+    pub fn allowed_networks(self, networks: &[&str]) -> Self {
+        Self {
+            handler: Arc::new(PaymentHandler::new(
+                self.handler.config().clone().allowed_networks(networks),
+            )),
+        }
+    }
+
+    /// Enable or disable dry-run mode.
+    #[must_use]
+    pub fn dry_run(self, dry_run: bool) -> Self {
+        Self {
+            handler: Arc::new(PaymentHandler::new(
+                self.handler.config().clone().dry_run(dry_run),
+            )),
+        }
+    }
+
+    /// Get a reference to the payment handler.
+    pub fn handler(&self) -> &PaymentHandler {
+        &self.handler
+    }
+}
+
+/// Error type for payment middleware.
+#[derive(Debug)]
+pub struct PaymentMiddlewareError(pub PurlError);
+
+impl std::fmt::Display for PaymentMiddlewareError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "payment middleware error: {}", self.0)
+    }
+}
+
+impl std::error::Error for PaymentMiddlewareError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl From<PurlError> for PaymentMiddlewareError {
+    fn from(err: PurlError) -> Self {
+        Self(err)
+    }
+}
+
+#[async_trait::async_trait]
+impl Middleware for PaymentMiddleware {
+    async fn handle(
+        &self,
+        req: Request,
+        extensions: &mut http::Extensions,
+        next: Next<'_>,
+    ) -> reqwest_middleware::Result<Response> {
+        // Clone the request for potential retry
+        let cloned_req = req.try_clone();
+
+        // Make the initial request
+        let response = next.clone().run(req, extensions).await?;
+
+        // Check if payment is required
+        let status = response.status().as_u16();
+        if !self.handler.requires_payment(status) {
+            return Ok(response);
+        }
+
+        // Get WWW-Authenticate header
+        let www_auth = response
+            .headers()
+            .get("www-authenticate")
+            .and_then(|v| v.to_str().ok());
+
+        let www_auth = match www_auth {
+            Some(header) => header,
+            None => {
+                // No WWW-Authenticate header, return original response
+                return Ok(response);
+            }
+        };
+
+        // Check if it's a payment challenge
+        if !self.handler.is_payment_challenge(Some(www_auth)) {
+            // Not a payment challenge, return the original 402 response
+            return Ok(response);
+        }
+
+        // Parse and validate challenge
+        let challenge = self
+            .handler
+            .parse_challenge(www_auth)
+            .map_err(|e| reqwest_middleware::Error::Middleware(PaymentMiddlewareError(e).into()))?;
+
+        self.handler
+            .validate_challenge(&challenge)
+            .map_err(|e| reqwest_middleware::Error::Middleware(PaymentMiddlewareError(e).into()))?;
+
+        // Check dry-run mode
+        if self.handler.is_dry_run() {
+            return Err(reqwest_middleware::Error::Middleware(
+                PaymentMiddlewareError(PurlError::InvalidChallenge(
+                    "Dry-run mode enabled - payment not executed".to_string(),
+                ))
+                .into(),
+            ));
+        }
+
+        // Create payment credential
+        let credential = self
+            .handler
+            .create_credential(&challenge)
+            .await
+            .map_err(|e| reqwest_middleware::Error::Middleware(PaymentMiddlewareError(e).into()))?;
+
+        // Format authorization header
+        let auth_header = self
+            .handler
+            .format_authorization(&credential)
+            .map_err(|e| reqwest_middleware::Error::Middleware(PaymentMiddlewareError(e).into()))?;
+
+        // Get the cloned request for retry
+        let mut retry_req = cloned_req.ok_or_else(|| {
+            reqwest_middleware::Error::Middleware(
+                PaymentMiddlewareError(PurlError::Http(
+                    "Failed to clone request for retry - request body may not be clonable"
+                        .to_string(),
+                ))
+                .into(),
+            )
+        })?;
+
+        // Add authorization header
+        retry_req.headers_mut().insert(
+            AUTHORIZATION_HEADER,
+            auth_header.parse().map_err(|_| {
+                reqwest_middleware::Error::Middleware(
+                    PaymentMiddlewareError(PurlError::Http(
+                        "Invalid authorization header value".to_string(),
+                    ))
+                    .into(),
+                )
+            })?,
+        );
+
+        // Retry the request with payment credential
+        next.run(retry_req, extensions).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_payment_middleware_new() {
+        let config = Config::default();
+        let _middleware = PaymentMiddleware::from_config(config);
+    }
+
+    #[test]
+    fn test_payment_middleware_builder() {
+        let config = Config::default();
+        let middleware = PaymentMiddleware::from_config(config)
+            .max_amount("1000000")
+            .allowed_networks(&["base"])
+            .dry_run(true);
+
+        assert!(middleware.handler.is_dry_run());
+    }
+
+    #[test]
+    fn test_payment_middleware_error_display() {
+        let err = PaymentMiddlewareError(PurlError::Http("test error".to_string()));
+        assert!(err.to_string().contains("payment middleware error"));
+        assert!(err.to_string().contains("test error"));
+    }
+}

--- a/lib/src/middleware/tower.rs
+++ b/lib/src/middleware/tower.rs
@@ -1,0 +1,393 @@
+//! Tower middleware for automatic payment handling.
+//!
+//! This module provides a Tower [`Layer`] and [`Service`] implementation that
+//! automatically handles HTTP 402 Payment Required responses using the Web
+//! Payment Auth protocol.
+//!
+//! # Overview
+//!
+//! The Tower middleware integrates with the Tower service ecosystem, allowing
+//! you to add payment handling to any Tower-compatible HTTP client (hyper,
+//! reqwest with tower, tonic, etc.).
+//!
+//! # Example
+//!
+//! ```ignore
+//! use purl::middleware::{PaymentLayer, PaymentHandlerConfig};
+//! use tower::ServiceBuilder;
+//!
+//! let config = purl::Config::load()?;
+//! let payment_config = PaymentHandlerConfig::new(config)
+//!     .max_amount("1000000")
+//!     .allowed_networks(&["base", "tempo"]);
+//!
+//! let service = ServiceBuilder::new()
+//!     .layer(PaymentLayer::new(payment_config))
+//!     .service(inner_http_client);
+//!
+//! // Now all requests through `service` will automatically handle 402 responses
+//! let response = service.call(request).await?;
+//! ```
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use http::{Request, Response};
+use http_body::Body;
+use pin_project_lite::pin_project;
+use tower::{Layer, Service};
+
+use super::{PaymentHandler, PaymentHandlerConfig};
+use crate::config::Config;
+use crate::error::PurlError;
+use crate::protocol::web::AUTHORIZATION_HEADER;
+
+/// Tower [`Layer`] that adds payment handling to an HTTP service.
+///
+/// This layer wraps an inner service and intercepts 402 Payment Required
+/// responses, automatically negotiating and submitting payments before
+/// retrying the request.
+///
+/// # Example
+///
+/// ```ignore
+/// use purl::middleware::{PaymentLayer, PaymentHandlerConfig};
+/// use tower::ServiceBuilder;
+///
+/// let config = purl::Config::load()?;
+/// let service = ServiceBuilder::new()
+///     .layer(PaymentLayer::new(PaymentHandlerConfig::new(config)))
+///     .service(hyper_client);
+/// ```
+#[derive(Debug, Clone)]
+pub struct PaymentLayer {
+    handler: Arc<PaymentHandler>,
+}
+
+impl PaymentLayer {
+    /// Create a new payment layer with the given configuration.
+    pub fn new(config: PaymentHandlerConfig) -> Self {
+        Self {
+            handler: Arc::new(PaymentHandler::new(config)),
+        }
+    }
+
+    /// Create a new payment layer from a purl Config.
+    ///
+    /// This is a convenience method that creates a default `PaymentHandlerConfig`.
+    pub fn from_config(config: Config) -> Self {
+        Self::new(PaymentHandlerConfig::new(config))
+    }
+
+    /// Set the maximum amount willing to pay.
+    #[must_use]
+    pub fn max_amount(self, amount: impl Into<String>) -> Self {
+        Self {
+            handler: Arc::new(PaymentHandler::new(
+                self.handler.config().clone().max_amount(amount),
+            )),
+        }
+    }
+
+    /// Restrict payments to only these networks.
+    #[must_use]
+    pub fn allowed_networks(self, networks: &[&str]) -> Self {
+        Self {
+            handler: Arc::new(PaymentHandler::new(
+                self.handler.config().clone().allowed_networks(networks),
+            )),
+        }
+    }
+
+    /// Enable or disable dry-run mode.
+    #[must_use]
+    pub fn dry_run(self, dry_run: bool) -> Self {
+        Self {
+            handler: Arc::new(PaymentHandler::new(
+                self.handler.config().clone().dry_run(dry_run),
+            )),
+        }
+    }
+}
+
+impl<S> Layer<S> for PaymentLayer {
+    type Service = PaymentService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        PaymentService {
+            inner,
+            handler: Arc::clone(&self.handler),
+        }
+    }
+}
+
+/// Tower [`Service`] that handles payment-required responses.
+///
+/// This service wraps an inner HTTP service and intercepts 402 Payment Required
+/// responses. When a 402 is received with a Payment challenge, this service:
+///
+/// 1. Parses the payment challenge from WWW-Authenticate header
+/// 2. Validates the challenge against configured limits
+/// 3. Creates a payment credential using the appropriate provider
+/// 4. Retries the original request with the Authorization header
+///
+/// # Type Parameters
+///
+/// - `S`: The inner service type
+#[derive(Debug, Clone)]
+pub struct PaymentService<S> {
+    inner: S,
+    handler: Arc<PaymentHandler>,
+}
+
+impl<S> PaymentService<S> {
+    /// Create a new payment service wrapping the given inner service.
+    pub fn new(inner: S, config: PaymentHandlerConfig) -> Self {
+        Self {
+            inner,
+            handler: Arc::new(PaymentHandler::new(config)),
+        }
+    }
+
+    /// Get a reference to the inner service.
+    pub fn inner(&self) -> &S {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the inner service.
+    pub fn inner_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    /// Consume this service, returning the inner service.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+
+    /// Get a reference to the payment handler.
+    pub fn handler(&self) -> &PaymentHandler {
+        &self.handler
+    }
+}
+
+/// Error type for the payment service.
+///
+/// This wraps both errors from the inner service and payment-related errors.
+#[derive(Debug)]
+pub enum PaymentServiceError<E> {
+    /// Error from the inner service
+    Inner(E),
+    /// Payment-related error
+    Payment(PurlError),
+}
+
+impl<E: std::fmt::Display> std::fmt::Display for PaymentServiceError<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Inner(e) => write!(f, "inner service error: {}", e),
+            Self::Payment(e) => write!(f, "payment error: {}", e),
+        }
+    }
+}
+
+impl<E: std::error::Error + 'static> std::error::Error for PaymentServiceError<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Inner(e) => Some(e),
+            Self::Payment(e) => Some(e),
+        }
+    }
+}
+
+impl<E> From<PurlError> for PaymentServiceError<E> {
+    fn from(err: PurlError) -> Self {
+        Self::Payment(err)
+    }
+}
+
+pin_project! {
+    /// Future returned by [`PaymentService`].
+    ///
+    /// This future handles the payment retry logic, including parsing challenges,
+    /// creating credentials, and retrying requests.
+    pub struct PaymentFuture<F, ReqBody> {
+        #[pin]
+        state: PaymentFutureState<F, ReqBody>,
+        handler: Arc<PaymentHandler>,
+    }
+}
+
+pin_project! {
+    #[project = PaymentFutureStateProj]
+    enum PaymentFutureState<F, ReqBody> {
+        /// Initial request in progress
+        Initial {
+            #[pin]
+            future: F,
+            request: Option<Request<ReqBody>>,
+        },
+        /// Creating payment credential
+        CreatingPayment {
+            challenge_id: String,
+            www_authenticate: String,
+            request: Option<Request<ReqBody>>,
+        },
+        /// Retry request with payment in progress
+        Retry {
+            #[pin]
+            future: F,
+        },
+    }
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for PaymentService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send,
+    S::Error: std::error::Error + Send + 'static,
+    ReqBody: Body + Clone + Send + 'static,
+    ResBody: Body + Send + 'static,
+{
+    type Response = Response<ResBody>;
+    type Error = PaymentServiceError<S::Error>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner
+            .poll_ready(cx)
+            .map_err(PaymentServiceError::Inner)
+    }
+
+    fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
+        let handler = Arc::clone(&self.handler);
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            // Make the initial request
+            let cloned_request = clone_request(&request);
+            let response = inner
+                .call(request)
+                .await
+                .map_err(PaymentServiceError::Inner)?;
+
+            // Check if payment is required
+            let status = response.status().as_u16();
+            if !handler.requires_payment(status) {
+                return Ok(response);
+            }
+
+            // Get WWW-Authenticate header
+            let www_auth = response
+                .headers()
+                .get("www-authenticate")
+                .and_then(|v| v.to_str().ok())
+                .ok_or_else(|| {
+                    PaymentServiceError::Payment(PurlError::MissingHeader(
+                        "WWW-Authenticate".to_string(),
+                    ))
+                })?;
+
+            // Check if it's a payment challenge
+            if !handler.is_payment_challenge(Some(www_auth)) {
+                // Not a payment challenge, return the original 402 response
+                return Ok(response);
+            }
+
+            // Parse and validate challenge
+            let challenge = handler.parse_challenge(www_auth)?;
+            handler.validate_challenge(&challenge)?;
+
+            // Check dry-run mode
+            if handler.is_dry_run() {
+                return Err(PaymentServiceError::Payment(PurlError::InvalidChallenge(
+                    "Dry-run mode enabled - payment not executed".to_string(),
+                )));
+            }
+
+            // Create payment credential
+            let credential = handler.create_credential(&challenge).await?;
+
+            // Format authorization header
+            let auth_header = handler.format_authorization(&credential)?;
+
+            // Retry with payment credential
+            let mut retry_request = cloned_request.ok_or_else(|| {
+                PaymentServiceError::Payment(PurlError::Http(
+                    "Failed to clone request for retry".to_string(),
+                ))
+            })?;
+
+            retry_request.headers_mut().insert(
+                AUTHORIZATION_HEADER,
+                auth_header.parse().map_err(|_| {
+                    PaymentServiceError::Payment(PurlError::Http(
+                        "Invalid authorization header value".to_string(),
+                    ))
+                })?,
+            );
+
+            inner
+                .call(retry_request)
+                .await
+                .map_err(PaymentServiceError::Inner)
+        })
+    }
+}
+
+/// Clone an HTTP request.
+///
+/// This attempts to clone the request for retry purposes. Returns None if
+/// the body cannot be cloned.
+fn clone_request<B: Clone>(request: &Request<B>) -> Option<Request<B>> {
+    let mut builder = Request::builder()
+        .method(request.method().clone())
+        .uri(request.uri().clone())
+        .version(request.version());
+
+    // Copy headers
+    if let Some(headers) = builder.headers_mut() {
+        headers.extend(
+            request
+                .headers()
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone())),
+        );
+    }
+
+    builder.body(request.body().clone()).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_payment_layer_new() {
+        let config = Config::default();
+        let _layer = PaymentLayer::from_config(config);
+    }
+
+    #[test]
+    fn test_payment_layer_builder() {
+        let config = Config::default();
+        let layer = PaymentLayer::from_config(config)
+            .max_amount("1000000")
+            .allowed_networks(&["base"])
+            .dry_run(true);
+
+        assert!(layer.handler.is_dry_run());
+    }
+
+    #[test]
+    fn test_payment_service_error_display() {
+        let inner_err: PaymentServiceError<std::io::Error> =
+            PaymentServiceError::Inner(std::io::Error::new(std::io::ErrorKind::Other, "test"));
+        assert!(inner_err.to_string().contains("inner service error"));
+
+        let payment_err: PaymentServiceError<std::io::Error> =
+            PaymentServiceError::Payment(PurlError::Http("test".to_string()));
+        assert!(payment_err.to_string().contains("payment error"));
+    }
+}

--- a/lib/src/prelude.rs
+++ b/lib/src/prelude.rs
@@ -1,0 +1,41 @@
+//! Convenient re-exports for common purl types.
+//!
+//! This module provides a convenient set of imports for the most commonly used
+//! types in the purl library. Instead of importing each type individually,
+//! you can use:
+//!
+//! ```ignore
+//! use purl::prelude::*;
+//! ```
+//!
+//! # What's included
+//!
+//! - **Configuration**: [`Config`], [`ConfigBuilder`], [`EvmConfig`]
+//! - **Client**: [`Client`], [`ClientBuilder`] (with `client` feature)
+//! - **Errors**: [`PurlError`], [`Result`]
+//! - **Protocol**: [`PaymentChallenge`], [`PaymentCredential`], [`PaymentMethod`]
+//! - **Middleware**: [`PaymentHandler`], [`PaymentHandlerConfig`] (with middleware features)
+
+// Core types - always available
+pub use crate::config::{Config, ConfigBuilder, EvmConfig};
+pub use crate::error::{PurlError, Result, ResultExt, SigningContext};
+
+// Protocol types
+pub use crate::protocol::web::{
+    ChargeRequest, PaymentChallenge, PaymentCredential, PaymentIntent, PaymentMethod,
+    PaymentPayload, PaymentProtocol, PaymentReceipt,
+};
+
+// Client types (feature-gated)
+#[cfg(feature = "client")]
+pub use crate::client::{Client, ClientBuilder, PaymentResult};
+
+// Middleware types (feature-gated)
+#[cfg(any(feature = "tower-middleware", feature = "reqwest-middleware"))]
+pub use crate::middleware::{PaymentHandler, PaymentHandlerConfig};
+
+#[cfg(feature = "tower-middleware")]
+pub use crate::middleware::{PaymentLayer, PaymentService};
+
+#[cfg(feature = "reqwest-middleware")]
+pub use crate::middleware::PaymentMiddleware;


### PR DESCRIPTION
## Summary

Add middleware module that integrates purl with existing HTTP client ecosystems, addressing the gap identified in the design review for "pluggable middleware for various Rust HTTP clients."

**New Components:**
- `PaymentHandler`: HTTP-client-agnostic payment handling core
- `PaymentLayer`/`PaymentService`: Tower middleware for hyper, axum, tonic
- `PaymentMiddleware`: reqwest-middleware integration  
- `ConfigBuilder`: Fluent API for programmatic configuration
- `prelude` module: Convenient re-exports for common types

**New Feature Flags:**
- `tower-middleware`: Tower Layer/Service implementation
- `reqwest-middleware`: reqwest-middleware crate integration
- `middleware`: All middleware features combined

## Usage Examples

### Tower Middleware
```rust
use purl::middleware::{PaymentLayer, PaymentHandlerConfig};
use tower::ServiceBuilder;

let config = purl::Config::load()?;
let service = ServiceBuilder::new()
    .layer(PaymentLayer::new(PaymentHandlerConfig::new(config))
        .max_amount("1000000"))
    .service(hyper_client);
```

### Reqwest Middleware
```rust
use purl::middleware::{PaymentMiddleware, PaymentHandlerConfig};
use reqwest_middleware::ClientBuilder;

let config = purl::Config::load()?;
let client = ClientBuilder::new(reqwest::Client::new())
    .with(PaymentMiddleware::new(PaymentHandlerConfig::new(config)))
    .build();
```

### ConfigBuilder
```rust
let config = purl::Config::builder()
    .evm_private_key("your_key_here")
    .rpc_override("base", "https://my-rpc.com")
    .build();
```

## Test plan

- [x] `cargo build --features tower-middleware` compiles
- [x] `cargo build --features reqwest-middleware` compiles
- [x] `cargo build --features full,middleware` compiles
- [x] `cargo test --features full,middleware` passes (245 tests)