### PR TITLE
fix: use integer arithmetic in Currency::format_atomic to prevent precision loss

### DIFF
--- a/lib/src/currency.rs
+++ b/lib/src/currency.rs
@@ -27,8 +27,16 @@ impl Currency {
 
     /// Format atomic units to human-readable string with appropriate decimal places
     pub fn format_atomic(&self, atomic: u128) -> String {
-        let value = atomic as f64 / self.divisor as f64;
-        format!("{:.1$}", value, self.decimals as usize)
+        let divisor = self.divisor as u128;
+        let whole = atomic / divisor;
+        let remainder = atomic % divisor;
+
+        if self.decimals == 0 {
+            whole.to_string()
+        } else {
+            let frac_str = format!("{:0width$}", remainder, width = self.decimals as usize);
+            format!("{whole}.{frac_str}")
+        }
     }
 
     /// Parse atomic units from a string


### PR DESCRIPTION
## Summary

The `format_atomic` method in `lib/src/currency.rs` was using `f64` division which causes **precision loss for tokens with 18 decimals** (like ETH). This is dangerous for payment applications.

## Problem

```rust
// Before (lines 29-32)
pub fn format_atomic(&self, atomic: u128) -> String {
    let value = atomic as f64 / self.divisor as f64;  // Precision loss!
    format!("{:.1$}", value, self.decimals as usize)
}
```

For example, `f64` can only exactly represent integers up to 2^53 (~9 quadrillion). For 18-decimal tokens, this means amounts over ~9000 ETH could have rounding errors.

## Solution

Use integer division and modulo (the same pattern already used by `format_trimmed`):

```rust
// After
pub fn format_atomic(&self, atomic: u128) -> String {
    let divisor = self.divisor as u128;
    let whole = atomic / divisor;
    let remainder = atomic % divisor;

    if self.decimals == 0 {
        whole.to_string()
    } else {
        let frac_str = format!("{:0width$}", remainder, width = self.decimals as usize);
        format!("{whole}.{frac_str}")
    }
}
```

## Testing

- All 233 existing tests pass
- The existing tests for `format_atomic` (lines 118-125, 128-138) verify correct behavior
- `make check` passes

## Related Issues

This is one of four issues identified in a code review:
1. **Float-based currency formatting** (this PR) - `lib/src/currency.rs:29-32`
2. Panic in ClientBuilder::build() - `lib/src/client.rs:175`
3. Silent unwrap_or(0) - `lib/src/currency.rs:65-77`
4. Silent header drops - `lib/src/http.rs:236-247`