### PR TITLE
fix: return Result from format_trimmed_from_str and format_atomic_trimmed

### DIFF
--- a/cli/src/inspect_command.rs
+++ b/cli/src/inspect_command.rs
@@ -147,11 +147,7 @@ fn format_charge_amount(req: &ChargeRequest, challenge: &PaymentChallenge) -> Op
     let decimals = token_config.currency.decimals;
     let symbol = token_config.currency.symbol;
 
-    Some(purl::currency::format_atomic_trimmed(
-        &amount.to_string(),
-        decimals,
-        symbol,
-    ))
+    purl::currency::format_atomic_trimmed(&amount.to_string(), decimals, symbol).ok()
 }
 
 fn output_json(

--- a/lib/src/currency.rs
+++ b/lib/src/currency.rs
@@ -62,9 +62,16 @@ impl Currency {
     /// Format atomic units from a string with trimmed trailing zeros
     ///
     /// Useful when the atomic value is provided as a string (e.g., from JSON).
-    pub fn format_trimmed_from_str(&self, atomic_str: &str) -> String {
-        let atomic: u128 = atomic_str.parse().unwrap_or(0);
-        self.format_trimmed(atomic)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the string cannot be parsed as a valid u128.
+    pub fn format_trimmed_from_str(
+        &self,
+        atomic_str: &str,
+    ) -> Result<String, std::num::ParseIntError> {
+        let atomic: u128 = atomic_str.parse()?;
+        Ok(self.format_trimmed(atomic))
     }
 }
 
@@ -72,18 +79,26 @@ impl Currency {
 ///
 /// This is a standalone function for formatting when you don't have a Currency instance.
 /// Uses the same logic as Currency::format_trimmed but accepts dynamic values.
-pub fn format_atomic_trimmed(atomic_str: &str, decimals: u8, symbol: &str) -> String {
-    let atomic: u128 = atomic_str.parse().unwrap_or(0);
+///
+/// # Errors
+///
+/// Returns an error if the atomic string cannot be parsed as a valid u128.
+pub fn format_atomic_trimmed(
+    atomic_str: &str,
+    decimals: u8,
+    symbol: &str,
+) -> Result<String, std::num::ParseIntError> {
+    let atomic: u128 = atomic_str.parse()?;
     let divisor = 10_u128.pow(decimals as u32);
     let whole = atomic / divisor;
     let remainder = atomic % divisor;
 
     if remainder == 0 {
-        format!("{whole} {symbol}")
+        Ok(format!("{whole} {symbol}"))
     } else {
         let frac_str = format!("{:0width$}", remainder, width = decimals as usize);
         let trimmed = frac_str.trim_end_matches('0');
-        format!("{whole}.{trimmed} {symbol}")
+        Ok(format!("{whole}.{trimmed} {symbol}"))
     }
 }
 
@@ -161,9 +176,9 @@ mod tests {
     #[test]
     fn test_format_trimmed_from_str() {
         let usdc = currencies::USDC;
-        assert_eq!(usdc.format_trimmed_from_str("1000000"), "1 USDC");
-        assert_eq!(usdc.format_trimmed_from_str("1500000"), "1.5 USDC");
-        assert_eq!(usdc.format_trimmed_from_str("invalid"), "0 USDC");
+        assert_eq!(usdc.format_trimmed_from_str("1000000").unwrap(), "1 USDC");
+        assert_eq!(usdc.format_trimmed_from_str("1500000").unwrap(), "1.5 USDC");
+        assert!(usdc.format_trimmed_from_str("invalid").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The `format_trimmed_from_str` and `format_atomic_trimmed` functions in `lib/src/currency.rs` silently converted parse failures to `0` amounts using `unwrap_or(0)`. This could hide bugs and cause incorrect behavior (e.g., displaying "0 USDC" for invalid input instead of reporting an error).

## Changes

- Changed `Currency::format_trimmed_from_str` to return `Result<String, std::num::ParseIntError>`
- Changed `format_atomic_trimmed` to return `Result<String, std::num::ParseIntError>`
- Updated tests to verify error handling works correctly
- Updated the caller in `inspect_command.rs` to use `.ok()` to maintain existing behavior

## Testing

`make check` passes (fmt, clippy, all 459 tests, build).