### PR TITLE
fix: warn when HTTP headers are dropped due to invalid name/value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,5 +43,8 @@ pin-project-lite = "0.2"
 # Reqwest middleware
 reqwest-middleware = "0.4"
 
+# Logging
+tracing = "0.1"
+
 # Tempo transaction types (used for Tempo network support)
 tempo-primitives = { git = "https://github.com/tempoxyz/tempo.git", rev = "07dfcd2d2b8c109d6b8502515c7db00198a8b3a3", features = ["serde"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,7 +23,7 @@ utils = ["dep:bs58", "dep:hex", "dep:base64", "dep:rand"]
 config = ["dep:toml", "dep:regex"]
 
 # HTTP client support (using reqwest) - async by default
-http-client = ["dep:reqwest", "runtime"]
+http-client = ["dep:reqwest", "dep:tracing", "runtime"]
 
 # Blocking HTTP client (synchronous API wrapper)
 blocking = ["http-client", "reqwest/blocking"]
@@ -80,6 +80,7 @@ toml = { workspace = true, optional = true }
 
 # HTTP client
 reqwest = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
 
 # Keystore
 zeroize = { workspace = true, optional = true }

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 use std::time::Duration;
+use tracing::warn;
 
 /// HTTP request methods.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
@@ -236,12 +237,21 @@ impl HttpClient {
         if !config.headers.is_empty() {
             let mut header_map = reqwest::header::HeaderMap::new();
             for (name, value) in &config.headers {
-                if let (Ok(header_name), Ok(header_value)) = (
-                    reqwest::header::HeaderName::from_bytes(name.as_bytes()),
-                    reqwest::header::HeaderValue::from_str(value),
-                ) {
-                    header_map.insert(header_name, header_value);
-                }
+                let header_name = match reqwest::header::HeaderName::from_bytes(name.as_bytes()) {
+                    Ok(n) => n,
+                    Err(e) => {
+                        warn!(header_name = %name, error = %e, "dropping header with invalid name");
+                        continue;
+                    }
+                };
+                let header_value = match reqwest::header::HeaderValue::from_str(value) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        warn!(header_name = %name, header_value = %value, error = %e, "dropping header with invalid value");
+                        continue;
+                    }
+                };
+                header_map.insert(header_name, header_value);
             }
             builder = builder.default_headers(header_map);
         }
@@ -379,12 +389,22 @@ pub mod blocking {
             if !config.headers.is_empty() {
                 let mut header_map = reqwest::header::HeaderMap::new();
                 for (name, value) in &config.headers {
-                    if let (Ok(header_name), Ok(header_value)) = (
-                        reqwest::header::HeaderName::from_bytes(name.as_bytes()),
-                        reqwest::header::HeaderValue::from_str(value),
-                    ) {
-                        header_map.insert(header_name, header_value);
-                    }
+                    let header_name = match reqwest::header::HeaderName::from_bytes(name.as_bytes())
+                    {
+                        Ok(n) => n,
+                        Err(e) => {
+                            warn!(header_name = %name, error = %e, "dropping header with invalid name");
+                            continue;
+                        }
+                    };
+                    let header_value = match reqwest::header::HeaderValue::from_str(value) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            warn!(header_name = %name, header_value = %value, error = %e, "dropping header with invalid value");
+                            continue;
+                        }
+                    };
+                    header_map.insert(header_name, header_value);
                 }
                 builder = builder.default_headers(header_map);
             }


### PR DESCRIPTION
## Summary
Fix silent header drops in `lib/src/http.rs`. Headers with invalid names or values were silently ignored during `HttpClient::from_config`, which could hide configuration problems.

## Changes
- Add `tracing` dependency to the `http-client` feature
- Replace silent `if let` pattern with explicit match that logs warnings
- Emit structured `tracing::warn!` when headers are dropped, including:
  - The header name that failed
  - The header value (for value parse errors)
  - The specific parse error
- Fix applies to both async and blocking HTTP clients

## Example log output
```
WARN dropping header with invalid name, header_name="Invalid\x00Name", error="..."
WARN dropping header with invalid value, header_name="X-Custom", header_value="bad\x00value", error="..."
```

## Testing
- `make check` passes (fmt, clippy, tests, build)