### PR TITLE
fix(evm): use pending block tag for nonce to avoid collisions

### DIFF
--- a/lib/src/providers/evm.rs
+++ b/lib/src/providers/evm.rs
@@ -165,6 +165,7 @@ impl PaymentProvider for EvmProvider {
 
         let nonce = provider
             .get_transaction_count(from)
+            .pending()
             .await
             .with_signing_context(SigningContext {
                 network: Some(network_name.to_string()),


### PR DESCRIPTION
## Summary

Fixes a P1 correctness issue where nonce collisions occurred when there were pending transactions.

## Problem

In `lib/src/providers/evm.rs`, the EVM provider was using `provider.get_transaction_count(from)` which defaults to the "latest" block tag. This only counts confirmed transactions, causing nonce collisions when there are pending transactions in the mempool.

## Solution

Added `.pending()` modifier to use the "pending" block tag instead, which includes pending transactions in the count:

```rust
let nonce = provider
    .get_transaction_count(from)
    .pending()  // Include pending transactions in count
    .await
```

This ensures correct nonce assignment for both Tempo (type 0x76) and EIP-1559 transactions.

## Testing

- All 257 tests pass
- `make check` passes (fmt, clippy, tests, build)