### PR TITLE
chore: use quiet mode for test output in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,16 +18,16 @@ clean:
 
 # Run all tests (uses mocks, no network required)
 test:
-	cargo test
+	cargo test -- --quiet
 
 # Unit tests only (fastest, library tests only)
 test-fast:
-	cargo test --lib
+	cargo test --lib -- --quiet
 
 check:
 	cargo fmt --check
 	cargo clippy -- -D warnings
-	cargo test
+	cargo test -- --quiet
 	cargo build
 
 fix:


### PR DESCRIPTION
## Summary
- Add `--quiet` flag to `cargo test` commands in Makefile
- Applies to `test`, `test-fast`, and `check` targets

This reduces noise when all tests pass and makes it easier to spot failures - only failing tests are shown in the output.