### PR TITLE
fix: address critical security vulnerabilities

### DIFF
--- a/cli/src/config_utils.rs
+++ b/cli/src/config_utils.rs
@@ -15,6 +15,7 @@ pub fn load_config(config_path: Option<impl AsRef<Path>>) -> Result<Config> {
     Config::load_from(config_path).context("Failed to load configuration")
 }
 
+#[allow(deprecated)]
 pub fn load_config_with_overrides(cli: &Cli) -> Result<Config> {
     let mut config = load_config(cli.config.as_ref())?;
 

--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 
 const PURL_SKILL_CONTENT: &str = include_str!("../../.ai/skills/purl/SKILL.md");
 
+#[allow(deprecated)]
 pub fn run_init(force: bool, skip_ai: bool) -> Result<()> {
     let config_path = Config::default_config_path()?;
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -86,6 +86,7 @@ pub struct DecryptedKeys {
 }
 
 /// Decrypt all keystores upfront before displaying
+#[allow(deprecated)]
 pub fn decrypt_keystores_upfront(
     config: &purl::Config,
     use_password_cache: bool,

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -151,11 +151,26 @@ pub struct EvmConfig {
     pub keystore: Option<PathBuf>,
 
     /// Private key for EVM wallet (hex string without 0x prefix)
-    /// DEPRECATED: Use keystore instead for better security
+    ///
+    /// # Security Warning
+    ///
+    /// **DEPRECATED**: Storing private keys in configuration files is insecure.
+    /// Use an encrypted keystore instead (`purl method new`).
+    ///
+    /// Risks of plaintext private keys:
+    /// - Config files may be accidentally committed to version control
+    /// - Config files may be included in backups
+    /// - Config files may have incorrect permissions
+    /// - Other processes on the system may read the config file
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use encrypted keystore instead. Plaintext private keys are insecure."
+    )]
     pub private_key: Option<String>,
 }
 
+#[allow(deprecated)]
 impl EvmConfig {
     fn address_from_keystore(path: &Path) -> Result<String> {
         use crate::keystore::Keystore;
@@ -174,6 +189,7 @@ impl EvmConfig {
     }
 }
 
+#[allow(deprecated)]
 impl WalletConfig for EvmConfig {
     type Address = String;
 
@@ -460,6 +476,7 @@ impl fmt::Display for PaymentMethod {
 ///     .build();
 /// ```
 #[derive(Debug, Clone, Default)]
+#[allow(deprecated)]
 pub struct ConfigBuilder {
     evm_keystore: Option<PathBuf>,
     evm_private_key: Option<String>,
@@ -468,6 +485,7 @@ pub struct ConfigBuilder {
     custom_tokens: Vec<CustomToken>,
 }
 
+#[allow(deprecated)]
 impl ConfigBuilder {
     /// Create a new empty ConfigBuilder.
     pub fn new() -> Self {

--- a/lib/src/constants.rs
+++ b/lib/src/constants.rs
@@ -15,7 +15,8 @@ pub const CONFIG_FILE: &str = "config.toml";
 /// Keystores subdirectory name
 pub const KEYSTORES_DIR: &str = "keystores";
 
-/// Password cache subdirectory name
+/// Password cache subdirectory name (deprecated - cache is now in-memory only)
+#[deprecated(note = "Password cache is now in-memory only, not stored on disk")]
 pub const PASSWORD_CACHE_DIR: &str = "password_cache";
 
 /// Get the configured password cache duration
@@ -138,15 +139,16 @@ pub fn default_keystores_dir() -> Option<PathBuf> {
     purl_data_dir().map(|p| p.join(KEYSTORES_DIR))
 }
 
-/// Get the password cache directory (`~/.cache/purl/password_cache/`)
+/// Get the password cache directory (deprecated)
 ///
-/// Returns the path to the directory where temporarily cached keystore
-/// passwords are stored for the duration specified by [`password_cache_duration()`].
+/// # Deprecated
 ///
-/// # Returns
-///
-/// - `Some(PathBuf)` pointing to the password cache directory
-/// - `None` if the cache directory cannot be determined
+/// Password caching is now in-memory only for security reasons.
+/// This function is kept for backwards compatibility but the directory
+/// is no longer used. Use `clear_password_cache()` from the keystore module
+/// to clear the in-memory cache.
+#[deprecated(note = "Password cache is now in-memory only, not stored on disk")]
+#[allow(deprecated)]
 pub fn password_cache_dir() -> Option<PathBuf> {
     purl_cache_dir().map(|p| p.join(PASSWORD_CACHE_DIR))
 }

--- a/lib/src/keystore/cache.rs
+++ b/lib/src/keystore/cache.rs
@@ -1,23 +1,13 @@
 //! Password caching for keystores
+//!
+//! SECURITY: Passwords are cached in-memory only (never written to disk).
+//! Cache entries expire after the configured duration (default 5 minutes).
 
-use crate::constants::{password_cache_dir, password_cache_duration};
-use crate::error::{PurlError, Result};
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
+use crate::constants::password_cache_duration;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
-
-#[cfg(unix)]
-fn set_secure_permissions(path: &Path, mode: u32) -> std::io::Result<()> {
-    use std::fs::Permissions;
-    use std::os::unix::fs::PermissionsExt;
-    std::fs::set_permissions(path, Permissions::from_mode(mode))
-}
-
-#[cfg(not(unix))]
-fn set_secure_permissions(_path: &Path, _mode: u32) -> std::io::Result<()> {
-    Ok(())
-}
+use std::sync::{LazyLock, Mutex};
+use std::time::Instant;
 
 /// Type-safe identifier for a keystore
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -34,183 +24,125 @@ impl KeystoreId {
     }
 }
 
-/// Get the password cache directory
-fn get_password_cache_dir() -> Result<PathBuf> {
-    password_cache_dir().ok_or(PurlError::NoConfigDir)
+/// In-memory cache entry with timestamp
+struct CacheEntry {
+    password: String,
+    created_at: Instant,
 }
 
-/// Get the cache file path for a keystore
-fn get_cache_file_path(id: &KeystoreId) -> Result<PathBuf> {
-    let cache_dir = get_password_cache_dir()?;
-    get_cache_file_path_in_dir(id, &cache_dir)
-}
+/// Global in-memory password cache
+///
+/// SECURITY: This cache is never persisted to disk. Passwords are stored
+/// only in process memory and are cleared when:
+/// - The cache entry expires (default 5 minutes)
+/// - The process exits
+/// - `clear_password_cache()` is called
+/// - A decryption attempt fails (the specific entry is cleared)
+static PASSWORD_CACHE: LazyLock<Mutex<HashMap<KeystoreId, CacheEntry>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// Get the cache file path for a keystore in a specific directory (for testing)
-fn get_cache_file_path_in_dir(id: &KeystoreId, cache_dir: &Path) -> Result<PathBuf> {
-    if std::fs::create_dir_all(cache_dir).is_ok() {
-        set_secure_permissions(cache_dir, 0o700).ok();
-    }
-
-    let mut hasher = DefaultHasher::new();
-    id.0.hash(&mut hasher);
-    let hash = hasher.finish();
-
-    Ok(cache_dir.join(format!("{hash:x}.cache")))
-}
-
-/// Store a password in the cache
+/// Store a password in the in-memory cache
+///
+/// SECURITY: Passwords are stored in process memory only, never on disk.
+/// They expire after the configured duration (see `password_cache_duration()`).
 pub(crate) fn cache_password(id: KeystoreId, password: String) {
-    if let Ok(cache_file) = get_cache_file_path(&id) {
-        cache_password_to_file(&cache_file, &password);
+    let entry = CacheEntry {
+        password,
+        created_at: Instant::now(),
+    };
+
+    if let Ok(mut cache) = PASSWORD_CACHE.lock() {
+        cache.insert(id, entry);
     }
 }
 
-/// Store a password in a specific cache file
-fn cache_password_to_file(cache_file: &Path, password: &str) {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("System time should be after UNIX_EPOCH")
-        .as_secs();
-
-    let cache_entry = format!("{now}|{password}");
-    if std::fs::write(cache_file, &cache_entry).is_ok() {
-        set_secure_permissions(cache_file, 0o600).ok();
-    }
-}
-
-/// Retrieve a password from the cache
+/// Retrieve a password from the in-memory cache
+///
+/// Returns None if:
+/// - No password is cached for this keystore
+/// - The cached password has expired
 pub(crate) fn get_cached_password(id: &KeystoreId) -> Option<String> {
-    let cache_file = get_cache_file_path(id).ok()?;
-    get_cached_password_from_file(&cache_file)
-}
+    let mut cache = PASSWORD_CACHE.lock().ok()?;
 
-/// Retrieve a password from a specific cache file
-fn get_cached_password_from_file(cache_file: &Path) -> Option<String> {
-    let contents = std::fs::read_to_string(cache_file).ok()?;
-
-    let parts: Vec<&str> = contents.splitn(2, '|').collect();
-    if parts.len() != 2 {
-        return None;
+    if let Some(entry) = cache.get(id) {
+        let age = entry.created_at.elapsed();
+        if age <= password_cache_duration() {
+            return Some(entry.password.clone());
+        }
+        cache.remove(id);
     }
 
-    let timestamp: u64 = parts[0].parse().ok()?;
-    let password = parts[1];
-
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("System time should be after UNIX_EPOCH")
-        .as_secs();
-
-    let age = now.saturating_sub(timestamp);
-    if age > password_cache_duration().as_secs() {
-        std::fs::remove_file(cache_file).ok();
-        return None;
-    }
-
-    Some(password.to_string())
+    None
 }
 
 /// Clear the cached password for a specific keystore
 pub(crate) fn clear_cached_password(id: &KeystoreId) {
-    if let Ok(cache_file) = get_cache_file_path(id) {
-        std::fs::remove_file(&cache_file).ok();
+    if let Ok(mut cache) = PASSWORD_CACHE.lock() {
+        cache.remove(id);
     }
 }
 
-/// Clear all cached passwords
+/// Clear all cached passwords from memory
 pub fn clear_password_cache() {
-    if let Ok(cache_dir) = get_password_cache_dir() {
-        if cache_dir.exists() {
-            std::fs::remove_dir_all(&cache_dir).ok();
-        }
+    if let Ok(mut cache) = PASSWORD_CACHE.lock() {
+        cache.clear();
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::constants::DEFAULT_PASSWORD_CACHE_DURATION;
     use tempfile::TempDir;
-
-    // NOTE: These tests use isolated temp directories and don't modify HOME,
-    // so they can run in parallel without #[serial]
 
     #[test]
     fn test_password_cache_basic() {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let cache_dir = temp_dir.path().join("cache");
 
         let test_path = temp_dir.path().join("test.json");
         std::fs::write(&test_path, "{}").expect("Failed to write test file");
 
         let keystore_id = KeystoreId::new(&test_path);
-        let password = "test_password";
+        let password = "test_password".to_string();
 
-        let cache_file = get_cache_file_path_in_dir(&keystore_id, &cache_dir)
-            .expect("Failed to get cache file path");
+        assert!(get_cached_password(&keystore_id).is_none());
 
-        assert!(get_cached_password_from_file(&cache_file).is_none());
+        cache_password(keystore_id.clone(), password.clone());
 
-        cache_password_to_file(&cache_file, password);
-
-        let cached = get_cached_password_from_file(&cache_file);
+        let cached = get_cached_password(&keystore_id);
         assert!(cached.is_some());
         assert_eq!(cached.expect("Password should be cached"), password);
+
+        clear_cached_password(&keystore_id);
+        assert!(get_cached_password(&keystore_id).is_none());
     }
 
     #[test]
-    fn test_password_cache_expiration() {
+    fn test_clear_password_cache() {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let cache_dir = temp_dir.path().join("cache");
-        std::fs::create_dir_all(&cache_dir).expect("Failed to create cache directory");
 
-        let test_path = temp_dir.path().join("expire.json");
-        std::fs::write(&test_path, "{}").expect("Failed to write test file");
+        let test_path1 = temp_dir.path().join("test1.json");
+        let test_path2 = temp_dir.path().join("test2.json");
+        std::fs::write(&test_path1, "{}").expect("Failed to write test file");
+        std::fs::write(&test_path2, "{}").expect("Failed to write test file");
 
-        let keystore_id = KeystoreId::new(&test_path);
-        let password = "test_password";
+        let id1 = KeystoreId::new(&test_path1);
+        let id2 = KeystoreId::new(&test_path2);
 
-        let cache_file = get_cache_file_path_in_dir(&keystore_id, &cache_dir)
-            .expect("Failed to get cache file path");
+        cache_password(id1.clone(), "password1".to_string());
+        cache_password(id2.clone(), "password2".to_string());
 
-        let expired_timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_secs()
-            - DEFAULT_PASSWORD_CACHE_DURATION.as_secs()
-            - 10;
+        assert!(get_cached_password(&id1).is_some());
+        assert!(get_cached_password(&id2).is_some());
 
-        let cache_entry = format!("{expired_timestamp}|{password}");
-        std::fs::write(&cache_file, cache_entry).expect("Failed to write cache entry");
+        clear_password_cache();
 
-        assert!(get_cached_password_from_file(&cache_file).is_none());
-        assert!(!cache_file.exists());
-    }
-
-    #[test]
-    fn test_clear_password_cache_in_dir() {
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let cache_dir = temp_dir.path().join("cache");
-        std::fs::create_dir_all(&cache_dir).expect("Failed to create cache directory");
-
-        let test_path = temp_dir.path().join("clear.json");
-        std::fs::write(&test_path, "{}").expect("Failed to write test file");
-
-        let keystore_id = KeystoreId::new(&test_path);
-        let cache_file = get_cache_file_path_in_dir(&keystore_id, &cache_dir)
-            .expect("Failed to get cache file path");
-
-        cache_password_to_file(&cache_file, "test_password");
-        assert!(get_cached_password_from_file(&cache_file).is_some());
-
-        std::fs::remove_dir_all(&cache_dir).expect("Failed to remove cache directory");
-        assert!(!cache_file.exists());
+        assert!(get_cached_password(&id1).is_none());
+        assert!(get_cached_password(&id2).is_none());
     }
 
     #[test]
     fn test_keystore_id_canonicalization() {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let cache_dir = temp_dir.path().join("cache");
 
         let test_path = temp_dir.path().join("canonical.json");
         std::fs::write(&test_path, "{}").expect("Failed to write test file");
@@ -224,33 +156,40 @@ mod tests {
 
         assert_eq!(id1, id2);
 
-        let file1 =
-            get_cache_file_path_in_dir(&id1, &cache_dir).expect("Failed to get cache file path");
-        let file2 =
-            get_cache_file_path_in_dir(&id2, &cache_dir).expect("Failed to get cache file path");
-        assert_eq!(file1, file2);
+        cache_password(id1.clone(), "password".to_string());
 
-        cache_password_to_file(&file1, "password");
-
-        let cached = get_cached_password_from_file(&file2);
+        let cached = get_cached_password(&id2);
         assert!(cached.is_some());
         assert_eq!(cached.expect("Password should be cached"), "password");
+
+        clear_cached_password(&id1);
     }
 
     #[test]
-    fn test_cache_file_path_hash_consistency() {
+    fn test_in_memory_only() {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let cache_dir = temp_dir.path().join("cache");
 
-        let test_path = temp_dir.path().join("hash_test.json");
+        let test_path = temp_dir.path().join("memory_test.json");
         std::fs::write(&test_path, "{}").expect("Failed to write test file");
 
         let keystore_id = KeystoreId::new(&test_path);
+        cache_password(keystore_id.clone(), "secret_password".to_string());
 
-        let path1 = get_cache_file_path_in_dir(&keystore_id, &cache_dir)
-            .expect("Failed to get cache file path");
-        let path2 = get_cache_file_path_in_dir(&keystore_id, &cache_dir)
-            .expect("Failed to get cache file path");
-        assert_eq!(path1, path2);
+        let cache_dir_entries: Vec<_> = std::fs::read_dir(temp_dir.path())
+            .expect("Failed to read temp directory")
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .map(|ext| ext == "cache")
+                    .unwrap_or(false)
+            })
+            .collect();
+        assert!(
+            cache_dir_entries.is_empty(),
+            "No .cache files should be created"
+        );
+
+        clear_cached_password(&keystore_id);
     }
 }

--- a/lib/src/keystore/encrypt.rs
+++ b/lib/src/keystore/encrypt.rs
@@ -10,6 +10,100 @@ pub fn default_keystore_dir() -> Result<PathBuf> {
     default_keystores_dir().ok_or(PurlError::NoConfigDir)
 }
 
+/// Validate and sanitize a keystore name to prevent path traversal attacks.
+///
+/// # Security
+///
+/// This function prevents:
+/// - Path traversal via `..` components
+/// - Absolute paths via leading `/` or Windows drive letters
+/// - Hidden files via leading `.`
+/// - Control characters that could cause issues
+/// - Path separators (`/`, `\`) in the name
+///
+/// # Returns
+///
+/// The sanitized name if valid, or an error describing the issue.
+fn validate_keystore_name(name: &str) -> Result<&str> {
+    if name.is_empty() {
+        return Err(PurlError::InvalidConfig(
+            "Keystore name cannot be empty".to_string(),
+        ));
+    }
+
+    if name.contains('/') || name.contains('\\') {
+        return Err(PurlError::InvalidConfig(format!(
+            "Keystore name cannot contain path separators: '{name}'"
+        )));
+    }
+
+    if name == "." || name == ".." || name.contains("..") {
+        return Err(PurlError::InvalidConfig(format!(
+            "Keystore name cannot contain path traversal sequences: '{name}'"
+        )));
+    }
+
+    if name.starts_with('.') {
+        return Err(PurlError::InvalidConfig(format!(
+            "Keystore name cannot start with a dot: '{name}'"
+        )));
+    }
+
+    if name.chars().any(|c| c.is_control()) {
+        return Err(PurlError::InvalidConfig(
+            "Keystore name cannot contain control characters".to_string(),
+        ));
+    }
+
+    const MAX_NAME_LENGTH: usize = 255;
+    if name.len() > MAX_NAME_LENGTH {
+        return Err(PurlError::InvalidConfig(format!(
+            "Keystore name too long (max {MAX_NAME_LENGTH} characters)"
+        )));
+    }
+
+    Ok(name)
+}
+
+/// Verify that the final keystore path is within the expected directory.
+///
+/// # Security
+///
+/// This is a defense-in-depth check to ensure that even after name validation,
+/// the final path doesn't escape the keystore directory through symlinks or
+/// other filesystem tricks.
+fn verify_path_within_directory(path: &Path, directory: &Path) -> Result<()> {
+    let canonical_dir = directory
+        .canonicalize()
+        .unwrap_or_else(|_| directory.to_path_buf());
+
+    let canonical_path =
+        if path.exists() {
+            path.canonicalize()
+                .map_err(|e| PurlError::InvalidConfig(format!("Failed to resolve path: {e}")))?
+        } else {
+            let parent = path.parent().ok_or_else(|| {
+                PurlError::InvalidConfig("Keystore path has no parent directory".to_string())
+            })?;
+            let parent_canonical = parent.canonicalize().map_err(|e| {
+                PurlError::InvalidConfig(format!("Failed to resolve parent path: {e}"))
+            })?;
+            parent_canonical.join(path.file_name().ok_or_else(|| {
+                PurlError::InvalidConfig("Keystore path has no filename".to_string())
+            })?)
+        };
+
+    if !canonical_path.starts_with(&canonical_dir) {
+        return Err(PurlError::InvalidConfig(format!(
+            "Keystore path escapes the keystore directory: {} is not within {}",
+            canonical_path.display(),
+            canonical_dir.display()
+        )));
+    }
+
+    Ok(())
+}
+
 /// Create an encrypted keystore file from a private key
 ///
 /// # Examples
@@ -37,6 +131,8 @@ pub(crate) fn create_keystore_in_dir(
     name: &str,
     keystore_dir: &Path,
 ) -> Result<PathBuf> {
+    let validated_name = validate_keystore_name(name)?;
+
     let key_hex = crate::utils::strip_0x_prefix(private_key);
     let key_bytes = hex::decode(key_hex)
         .map_err(|e| PurlError::InvalidKey(format!("Invalid private key hex: {e}")))?;
@@ -60,6 +156,13 @@ pub(crate) fn create_keystore_in_dir(
         ))
     })?;
 
+    #[cfg(unix)]
+    {
+        use std::fs::Permissions;
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(keystore_dir, Permissions::from_mode(0o700)).ok();
+    }
+
     if !keystore_dir.exists() {
         return Err(PurlError::ConfigMissing(format!(
             "Keystore directory does not exist after creation: {}",
@@ -68,7 +171,10 @@ pub(crate) fn create_keystore_in_dir(
     }
 
     let mut rng = rand::thread_rng();
-    let filename_with_ext = format!("{name}.{KEYSTORE_EXTENSION}");
+    let filename_with_ext = format!("{validated_name}.{KEYSTORE_EXTENSION}");
+    let keystore_path = keystore_dir.join(&filename_with_ext);
+
+    verify_path_within_directory(&keystore_path, keystore_dir)?;
 
     eth_keystore::encrypt_key(
         keystore_dir,
@@ -78,8 +184,6 @@ pub(crate) fn create_keystore_in_dir(
         Some(&filename_with_ext),
     )
     .map_err(|e| PurlError::ConfigMissing(format!("Failed to encrypt keystore: {e}")))?;
-
-    let keystore_path = keystore_dir.join(&filename_with_ext);
 
     let keystore_content = std::fs::read_to_string(&keystore_path)
         .map_err(|e| PurlError::ConfigMissing(format!("Failed to read keystore: {e}")))?;
@@ -319,6 +423,94 @@ mod tests {
         assert!(result.is_err());
 
         let result = create_keystore_in_dir("0xGGGG", "password", "invalid", &keystore_dir);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_keystore_name_valid() {
+        assert!(validate_keystore_name("my-wallet").is_ok());
+        assert!(validate_keystore_name("wallet_123").is_ok());
+        assert!(validate_keystore_name("MyWallet").is_ok());
+        assert!(validate_keystore_name("test").is_ok());
+    }
+
+    #[test]
+    fn test_validate_keystore_name_empty() {
+        let result = validate_keystore_name("");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn test_validate_keystore_name_path_traversal() {
+        let result = validate_keystore_name("../outside");
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("path traversal") || err_msg.contains("path separators"),
+            "Expected 'path traversal' or 'path separators' in error, got: {}",
+            err_msg
+        );
+
+        let result = validate_keystore_name("..");
+        assert!(result.is_err());
+
+        let result = validate_keystore_name("foo/../bar");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_keystore_name_path_separators() {
+        let result = validate_keystore_name("path/to/file");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("path separators"));
+
+        let result = validate_keystore_name("path\\to\\file");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_keystore_name_hidden_files() {
+        let result = validate_keystore_name(".hidden");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("start with a dot"));
+    }
+
+    #[test]
+    fn test_validate_keystore_name_control_chars() {
+        let result = validate_keystore_name("file\x00name");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("control characters"));
+
+        let result = validate_keystore_name("file\nname");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_keystore_name_too_long() {
+        let long_name = "a".repeat(300);
+        let result = validate_keystore_name(&long_name);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("too long"));
+    }
+
+    #[test]
+    fn test_path_traversal_in_create_keystore() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let keystore_dir = temp_dir.path().join("keystores");
+        std::fs::create_dir_all(&keystore_dir).expect("Failed to create keystore directory");
+
+        let private_key = "0x1234567890123456789012345678901234567890123456789012345678901234";
+
+        let result = create_keystore_in_dir(private_key, "password", "../escape", &keystore_dir);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("path traversal") || err.contains("path separators"));
+
+        let result = create_keystore_in_dir(private_key, "password", "foo/bar", &keystore_dir);
         assert!(result.is_err());
     }
 }

--- a/lib/src/protocol/methods/evm/types.rs
+++ b/lib/src/protocol/methods/evm/types.rs
@@ -33,9 +33,7 @@ mod tests {
 
     #[test]
     fn test_evm_method_details_serialization() {
-        let details = EvmMethodDetails {
-            chain_id: Some(1),
-        };
+        let details = EvmMethodDetails { chain_id: Some(1) };
 
         let json = serde_json::to_string(&details).unwrap();
         assert!(json.contains("\"chainId\":1"));

--- a/lib/src/signer.rs
+++ b/lib/src/signer.rs
@@ -38,6 +38,7 @@ impl WalletSource for WalletOpts {
     }
 }
 
+#[allow(deprecated)]
 impl WalletSource for crate::config::EvmConfig {
     fn load_signer(&self, password: Option<&str>) -> Result<PrivateKeySigner> {
         if let Some(keystore_path) = &self.keystore {


### PR DESCRIPTION
## Summary

Fixes three critical security vulnerabilities identified in a security audit.

## Changes

### PURL-001: Replace plaintext password caching with in-memory only (Critical)
- **Before**: Passwords were cached to disk as plaintext in `~/.cache/purl/password_cache/`
- **After**: Passwords stored in process memory only using `LazyLock<Mutex<HashMap>>`
- Deprecates `password_cache_dir()` and `PASSWORD_CACHE_DIR` constant

### PURL-002: Add path traversal protection to keystore creation (Critical)
- Added `validate_keystore_name()` to reject:
  - Path separators (`/`, `\`)
  - Path traversal sequences (`..`)
  - Hidden files (leading `.`)
  - Control characters
  - Names exceeding 255 chars
- Added `verify_path_within_directory()` as defense-in-depth
- Sets `0o700` permissions on keystore directory (Unix)

### PURL-003: Deprecate plaintext private key in config (Critical)
- Marks `EvmConfig::private_key` field as `#[deprecated]`
- Users will see compiler warnings when using the deprecated field
- Adds `#[allow(deprecated)]` to legitimate internal uses

## Testing

- All existing tests pass
- Added new tests for path traversal protection
- `make check` passes (fmt, clippy, tests, build)

## Security Impact

| ID | Before | After |
|----|--------|-------|
| PURL-001 | Plaintext passwords on disk | In-memory only |
| PURL-002 | Path traversal possible | Sanitized + verified |
| PURL-003 | Silent usage of insecure option | Compiler warnings |
