### PR TITLE
feat: unify insecure options into single --insecure flag

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -68,13 +68,9 @@ pub struct Cli {
     #[arg(short = 'D', long, help_heading = "Payment Options")]
     pub dry_run: bool,
 
-    /// Skip origin validation for payment challenges (DANGEROUS)
-    #[arg(
-        long = "insecure-skip-origin-check",
-        hide = true,
-        help_heading = "Payment Options"
-    )]
-    pub insecure_skip_origin_check: bool,
+    /// Allow insecure operations (skip TLS verification and origin checks)
+    #[arg(short = 'k', long = "insecure", help_heading = "Request Options")]
+    pub insecure: bool,
 
     // Display Options
     /// Verbosity level (can be used multiple times: -v, -vv, -vvv)

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -128,6 +128,7 @@ pub struct HttpClientConfig {
     pub(crate) follow_redirects: bool,
     pub(crate) user_agent: Option<String>,
     pub(crate) headers: Vec<(String, String)>,
+    pub(crate) insecure: bool,
 }
 
 /// Builder for configuring HTTP clients.
@@ -182,6 +183,12 @@ impl HttpClientBuilder {
         self
     }
 
+    /// Skip TLS certificate verification (DANGEROUS).
+    pub fn insecure(mut self, insecure: bool) -> Self {
+        self.config.insecure = insecure;
+        self
+    }
+
     /// Build the configured async HTTP client.
     pub fn build(self) -> Result<HttpClient> {
         HttpClient::from_config(self.config)
@@ -219,6 +226,12 @@ impl HttpClient {
             builder = builder.redirect(reqwest::redirect::Policy::limited(10));
         } else {
             builder = builder.redirect(reqwest::redirect::Policy::none());
+        }
+
+        if config.insecure {
+            builder = builder
+                .danger_accept_invalid_certs(true)
+                .danger_accept_invalid_hostnames(true);
         }
 
         if let Some(ref ua) = config.user_agent {

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -73,6 +73,7 @@ impl RequestContext {
         let mut builder = HttpClientBuilder::new()
             .verbose(self.cli.is_verbose())
             .follow_redirects(self.cli.follow_redirects)
+            .insecure(self.cli.insecure)
             .headers(&headers);
 
         if let Some(timeout) = self.cli.get_timeout() {

--- a/src/payment/web_payment.rs
+++ b/src/payment/web_payment.rs
@@ -59,7 +59,7 @@ fn validate_origin(url: &str, challenge: &PaymentChallenge, skip_check: bool) ->
         anyhow::bail!(
             "Payment challenge realm '{}' does not match request host '{}'. \
              This could indicate a malicious server. \
-             Use --insecure-skip-origin-check to bypass (DANGEROUS).",
+             Use --insecure to bypass (DANGEROUS).",
             challenge.realm,
             request_host
         );
@@ -88,7 +88,7 @@ pub async fn handle_web_payment_request(
         parse_www_authenticate(www_auth).context("Failed to parse WWW-Authenticate header")?;
 
     // SECURITY: Validate origin before proceeding
-    validate_origin(url, &challenge, request_ctx.cli.insecure_skip_origin_check)?;
+    validate_origin(url, &challenge, request_ctx.cli.insecure)?;
 
     // Get network and explorer config early for clickable links
     let network = method_to_network(&challenge.method)

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -216,6 +216,24 @@ fn test_help_has_http_options_section() {
 }
 
 #[test]
+fn test_help_has_request_options_section() {
+    Command::new(assert_cmd::cargo::cargo_bin!("purl"))
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Request Options:"));
+}
+
+#[test]
+fn test_insecure_flag_short() {
+    Command::new(assert_cmd::cargo::cargo_bin!("purl"))
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("-k, --insecure"));
+}
+
+#[test]
 fn test_help_has_wallet_options_section() {
     Command::new(assert_cmd::cargo::cargo_bin!("purl"))
         .arg("--help")


### PR DESCRIPTION
Consolidates `--insecure-skip-origin-check` and TLS certificate verification into a single `-k/--insecure` flag for simpler local development workflow.

When `--insecure` is set:
- TLS certificate verification is disabled (useful for self-signed certs)
- Origin validation for payment challenges is skipped

This replaces the hidden `--insecure-skip-origin-check` flag and adds the TLS bypass functionality from #68.

Closes #68