### PR TITLE
chore: rename R2 bucket from purl-binaries to pget-binaries

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ echo ""
 REPO="tempoxyz/pget"
 INSTALL_DIR="/usr/local/bin"
 BINARY_NAME="pget"
-R2_BASE_URL="https://purl-binaries.tempo.xyz"
+R2_BASE_URL="https://pget-binaries.tempo.xyz"
 
 # Temp directory for downloads (cleaned up on exit)
 TMP_DIR=""


### PR DESCRIPTION
Updates R2_BASE_URL to use new bucket name `pget-binaries`.

**Do not merge until:**
1. New R2 bucket `pget-binaries` is created
2. Contents copied from `purl-binaries`
3. DNS record `pget-binaries.tempo.xyz` is configured