### PR TITLE
fix: update R2 bucket from purl-binaries to pget-binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,17 +81,17 @@ jobs:
         run: |
           # Always upload binaries as "latest"
           for f in artifacts/*; do
-            aws s3 cp "$f" "s3://purl-binaries/$(basename "$f")" --endpoint-url "$AWS_ENDPOINT_URL"
+            aws s3 cp "$f" "s3://pget-binaries/$(basename "$f")" --endpoint-url "$AWS_ENDPOINT_URL"
           done
           
           # Upload install script
-          aws s3 cp install.sh "s3://purl-binaries/install.sh" --endpoint-url "$AWS_ENDPOINT_URL" --content-type "text/plain"
+          aws s3 cp install.sh "s3://pget-binaries/install.sh" --endpoint-url "$AWS_ENDPOINT_URL" --content-type "text/plain"
           
           # If this is a tag, also upload with version prefix
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/}"
             for f in artifacts/*; do
               BASENAME=$(basename "$f")
-              aws s3 cp "$f" "s3://purl-binaries/${VERSION}/${BASENAME}" --endpoint-url "$AWS_ENDPOINT_URL"
+              aws s3 cp "$f" "s3://pget-binaries/${VERSION}/${BASENAME}" --endpoint-url "$AWS_ENDPOINT_URL"
             done
           fi


### PR DESCRIPTION
Updates the release workflow to upload binaries to the new `pget-binaries` R2 bucket instead of `purl-binaries`.

The bucket `pget-binaries` has been created and configured with custom domain `pget-binaries.tempo.xyz`.