### PR TITLE
allow for swapping tokens on the tempo amm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1.0"
 mpay = { git = "https://github.com/tempoxyz/mpay-rs.git", branch = "main", features = ["tempo", "evm", "utils", "client"] }
 tokio = { version = "1.49", features = ["macros", "rt-multi-thread", "signal"] }
 async-trait = "0.1"
+futures = "0.3"
 bs58 = "0.5"
 hex = "0.4"
 base64 = "0.22"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Use as `pget <URL> [OPTIONS]` or `pget <COMMAND> [OPTIONS]`
 | Use specific account by name | `pget -a my-wallet https://api.example.com/data` |
 | Use specific sender address | `pget --from 0x1234... https://api.example.com/data` |
 | Override RPC URL | `pget -r https://my-rpc.com https://api.example.com/data` |
+| Disable automatic token swaps | `pget --no-swap https://api.example.com/data` |
 | View configuration | `pget config` or `pget c` |
 | View configuration with private keys | `pget config --unsafe-show-private-keys` |
 | Disable password caching | `pget --no-cache config --unsafe-show-private-keys` |
@@ -473,12 +474,53 @@ pget supports the Web Payment Auth protocol for HTTP-based payments.
 |----------|-------------|-------------------|
 | [Web Payment Auth](https://datatracker.ietf.org/doc/draft-ietf-httpauth-payment/) | IETF standard for HTTP authentication-based payments | `tempo`, `tempo-moderato` (plus any custom networks you define) |
 
+## Automatic Token Swapping
+
+When a merchant requests payment in a specific stablecoin that you don't have, pget can automatically swap from a stablecoin you do have. This feature is enabled by default.
+
+**How it works:**
+
+1. When a payment is requested, pget checks your balance of the required token
+2. If you have sufficient balance, the payment proceeds directly
+3. If you don't have enough of the required token, pget queries your balances of other supported stablecoins (pathUSD, AlphaUSD, BetaUSD, ThetaUSD)
+4. If another token has sufficient balance (including 0.5% slippage), pget automatically swaps via the Tempo StablecoinDEX and completes the payment in a single atomic transaction
+
+**Token selection:**
+
+pget checks tokens in order and uses the first one with sufficient balance. The balance check includes a 0.5% slippage buffer to ensure the swap succeeds.
+
+**Atomic execution:**
+
+The swap and payment are executed atomically in a single Tempo transaction containing three calls:
+1. Approve the DEX to spend your tokens
+2. Swap to the required token
+3. Transfer to the merchant
+
+If any step fails, the entire transaction reverts.
+
+**Disabling automatic swaps:**
+
+To disable automatic swapping and require exact token balance:
+
+```bash
+pget --no-swap https://api.example.com/data
+```
+
+Or set the environment variable:
+
+```bash
+export PGET_NO_SWAP=true
+```
+
+When swaps are disabled and you don't have enough of the required token, pget will display an error with your current balance and the required amount.
+
 ## Environment Variables
 
 ```bash
 export PGET_MAX_AMOUNT=10000
 export PGET_NETWORK=tempo-moderato
 export PGET_CONFIRM=true
+export PGET_NO_SWAP=true
 
 pget https://api.example.com/data
 ```
@@ -519,6 +561,7 @@ Payment Options:
   -y, --confirm              Require confirmation before paying [env: PGET_CONFIRM=]
   -n, --network <NETWORKS>   Filter to specific networks (comma-separated, e.g. "base,base-sepolia") [env: PGET_NETWORK=]
   -D, --dry-run              Dry run mode - show what would be paid without executing
+      --no-swap              Disable automatic token swaps [env: PGET_NO_SWAP=]
 
 Display Options:
   -v, --verbosity...            Verbosity level (can be used multiple times: -v, -vv, -vvv)

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -68,6 +68,14 @@ pub struct Cli {
     #[arg(short = 'D', long, help_heading = "Payment Options")]
     pub dry_run: bool,
 
+    /// Disable automatic token swaps when you don't have the requested currency
+    #[arg(
+        long = "no-swap",
+        env = "PGET_NO_SWAP",
+        help_heading = "Payment Options"
+    )]
+    pub no_swap: bool,
+
     /// Allow insecure operations (skip TLS verification and origin checks)
     #[arg(short = 'k', long = "insecure", help_heading = "Request Options")]
     pub insecure: bool,

--- a/src/payment/abi.rs
+++ b/src/payment/abi.rs
@@ -7,7 +7,15 @@ use alloy::sol_types::SolCall;
 sol! {
     function transfer(address to, uint256 amount) external returns (bool);
     function transferWithMemo(address to, uint256 amount, bytes32 memo) external returns (bool);
+    function approve(address spender, uint256 amount) external returns (bool);
+    function swapExactAmountOut(address tokenIn, address tokenOut, uint128 amountOut, uint128 maxAmountIn) external returns (uint128 amountIn);
 }
+
+/// StablecoinDEX contract address on Tempo networks.
+pub const DEX_ADDRESS: Address = Address::new([
+    0xde, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+]);
 
 /// Encode a token transfer call, optionally with memo.
 pub fn encode_transfer(recipient: Address, amount: U256, memo: Option<[u8; 32]>) -> Bytes {
@@ -25,6 +33,30 @@ pub fn encode_transfer(recipient: Address, amount: U256, memo: Option<[u8; 32]>)
         };
         Bytes::from(call.abi_encode())
     }
+}
+
+/// Encode an ERC20 approve call.
+pub fn encode_approve(spender: Address, amount: U256) -> Bytes {
+    let call = approveCall { spender, amount };
+    Bytes::from(call.abi_encode())
+}
+
+/// Encode a DEX swapExactAmountOut call.
+///
+/// Note: The DEX uses uint128 for amounts, not U256.
+pub fn encode_swap_exact_amount_out(
+    token_in: Address,
+    token_out: Address,
+    amount_out: u128,
+    max_amount_in: u128,
+) -> Bytes {
+    let call = swapExactAmountOutCall {
+        tokenIn: token_in,
+        tokenOut: token_out,
+        amountOut: amount_out,
+        maxAmountIn: max_amount_in,
+    };
+    Bytes::from(call.abi_encode())
 }
 
 #[cfg(test)]
@@ -58,5 +90,45 @@ mod tests {
         let data = encode_transfer(recipient, amount, Some(memo));
         // transferWithMemo(address,uint256,bytes32) selector
         assert_eq!(&data[0..4], &[0x95, 0x77, 0x7d, 0x59]);
+    }
+
+    #[test]
+    fn test_approve_encoding() {
+        let spender = DEX_ADDRESS;
+        let amount = U256::from(1_000_000u64);
+
+        let data = encode_approve(spender, amount);
+        // approve(address,uint256) selector: 0x095ea7b3
+        assert_eq!(&data[0..4], &[0x09, 0x5e, 0xa7, 0xb3]);
+        // Check data length: 4 (selector) + 32 (address) + 32 (amount) = 68 bytes
+        assert_eq!(data.len(), 68);
+    }
+
+    #[test]
+    fn test_swap_exact_amount_out_encoding() {
+        let token_in: Address = "0x20c0000000000000000000000000000000000001"
+            .parse()
+            .unwrap();
+        let token_out: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+        let amount_out: u128 = 1_000_000;
+        let max_amount_in: u128 = 1_005_000; // 0.5% slippage
+
+        let data = encode_swap_exact_amount_out(token_in, token_out, amount_out, max_amount_in);
+        // swapExactAmountOut(address,address,uint128,uint128) selector
+        // keccak256("swapExactAmountOut(address,address,uint128,uint128)")[0..4] = 0xf0122b75
+        assert_eq!(&data[0..4], &[0xf0, 0x12, 0x2b, 0x75]);
+        // Check data length: 4 (selector) + 32*4 (4 args) = 132 bytes
+        assert_eq!(data.len(), 132);
+    }
+
+    #[test]
+    fn test_dex_address_constant() {
+        // Verify DEX address is 0xdec0000000000000000000000000000000000000
+        assert_eq!(
+            format!("{:#x}", DEX_ADDRESS),
+            "0xdec0000000000000000000000000000000000000"
+        );
     }
 }

--- a/src/payment/mpay_ext.rs
+++ b/src/payment/mpay_ext.rs
@@ -54,14 +54,8 @@ pub fn validate_challenge(challenge: &PaymentChallenge) -> Result<()> {
 
 /// Pget-specific extensions to ChargeRequest.
 ///
-/// For core EVM accessors, use `TempoChargeExt` from mpay.
+/// For core EVM accessors (including `memo()`), use `TempoChargeExt` from mpay.
 pub trait ChargeRequestExt {
-    /// Get the memo from method details as a bytes32 value.
-    ///
-    /// Returns `None` if not specified in `methodDetails`.
-    /// The memo should be a hex-encoded 32-byte value (with or without 0x prefix).
-    fn memo(&self) -> Option<[u8; 32]>;
-
     /// Create a type-safe `Money` value from this charge request.
     ///
     /// Validates that the currency address matches the network's configured token.
@@ -69,24 +63,6 @@ pub trait ChargeRequestExt {
 }
 
 impl ChargeRequestExt for ChargeRequest {
-    fn memo(&self) -> Option<[u8; 32]> {
-        self.method_details
-            .as_ref()
-            .and_then(|v| v.get("memo"))
-            .and_then(|v| v.as_str())
-            .and_then(|s| {
-                let hex_str = s.strip_prefix("0x").unwrap_or(s);
-                let bytes = hex::decode(hex_str).ok()?;
-                if bytes.len() == 32 {
-                    let mut arr = [0u8; 32];
-                    arr.copy_from_slice(&bytes);
-                    Some(arr)
-                } else {
-                    None
-                }
-            })
-    }
-
     fn money(&self, network: Network) -> Result<Money> {
         use mpay::protocol::methods::tempo::TempoChargeExt;
 
@@ -165,61 +141,6 @@ mod tests {
             expires: None,
         };
         assert!(validate_challenge(&challenge).is_err());
-    }
-
-    #[test]
-    fn test_charge_request_memo_with_0x_prefix() {
-        let memo_hex = "0xc70864128216764ddcf3cc9b9fc1edb49c453e615e904f2847ba79dd0ec71001";
-        let req = ChargeRequest {
-            amount: "1000".to_string(),
-            currency: "0x123".to_string(),
-            method_details: Some(serde_json::json!({
-                "memo": memo_hex
-            })),
-            ..Default::default()
-        };
-        let memo = req.memo();
-        assert!(memo.is_some());
-        let memo_bytes = memo.unwrap();
-        assert_eq!(memo_bytes[0], 0xc7);
-        assert_eq!(memo_bytes[1], 0x08);
-    }
-
-    #[test]
-    fn test_charge_request_memo_without_prefix() {
-        let memo_hex = "c70864128216764ddcf3cc9b9fc1edb49c453e615e904f2847ba79dd0ec71001";
-        let req = ChargeRequest {
-            amount: "1000".to_string(),
-            currency: "0x123".to_string(),
-            method_details: Some(serde_json::json!({
-                "memo": memo_hex
-            })),
-            ..Default::default()
-        };
-        assert!(req.memo().is_some());
-    }
-
-    #[test]
-    fn test_charge_request_memo_missing() {
-        let req = ChargeRequest {
-            amount: "1000".to_string(),
-            currency: "0x123".to_string(),
-            ..Default::default()
-        };
-        assert!(req.memo().is_none());
-    }
-
-    #[test]
-    fn test_charge_request_memo_wrong_length() {
-        let req = ChargeRequest {
-            amount: "1000".to_string(),
-            currency: "0x123".to_string(),
-            method_details: Some(serde_json::json!({
-                "memo": "0x1234"
-            })),
-            ..Default::default()
-        };
-        assert!(req.memo().is_none());
     }
 
     #[test]

--- a/src/payment/provider.rs
+++ b/src/payment/provider.rs
@@ -7,6 +7,7 @@ use crate::config::Config;
 use crate::error::{PgetError, Result};
 use crate::network::Network;
 use crate::payment::money::format_u256_with_decimals;
+use crate::payment::providers::tempo::{SwapInfo, BPS_DENOMINATOR, SWAP_SLIPPAGE_BPS};
 use alloy::primitives::{Address, U256};
 use alloy::providers::ProviderBuilder;
 use alloy::sol;
@@ -52,16 +53,31 @@ impl std::fmt::Display for NetworkBalance {
 ///
 /// This provider handles both Tempo and EVM networks, automatically selecting
 /// the appropriate transaction format based on the payment method.
+///
+/// When `no_swap` is false (default), the provider will automatically swap from
+/// a different stablecoin if the user doesn't have the required token.
 #[derive(Clone)]
 pub struct PgetPaymentProvider {
     config: Arc<Config>,
+    /// If true, disable automatic token swaps.
+    no_swap: bool,
 }
 
 impl PgetPaymentProvider {
     /// Create a new provider with the given configuration.
+    #[allow(dead_code)]
     pub fn new(config: Config) -> Self {
         Self {
             config: Arc::new(config),
+            no_swap: false,
+        }
+    }
+
+    /// Create a new provider with swap behavior configured.
+    pub fn with_no_swap(config: Config, no_swap: bool) -> Self {
+        Self {
+            config: Arc::new(config),
+            no_swap,
         }
     }
 }
@@ -95,10 +111,105 @@ impl PgetPaymentProvider {
         &self,
         challenge: &mpay::PaymentChallenge,
     ) -> std::result::Result<mpay::PaymentCredential, mpay::MppError> {
-        use crate::payment::providers::tempo::create_tempo_payment;
-        create_tempo_payment(&self.config, challenge)
+        use crate::payment::mpay_ext::{method_to_network, TempoChargeExt};
+        use crate::payment::providers::tempo::{
+            create_tempo_payment, create_tempo_payment_with_swap,
+        };
+        use crate::wallet::signer::WalletSource;
+
+        // Parse the charge request to get required token and amount.
+        // Note: We use MppError::Http for parse errors since mpay doesn't expose a dedicated
+        // parse error variant. This is a workaround until mpay adds proper error types.
+        let charge_req: mpay::ChargeRequest = challenge
+            .request
+            .decode()
+            .map_err(|e| mpay::MppError::Http(format!("Invalid charge request: {}", e)))?;
+
+        let required_token = charge_req
+            .currency_address()
+            .map_err(|e| mpay::MppError::Http(format!("Invalid currency address: {}", e)))?;
+        let required_amount = charge_req
+            .amount_u256()
+            .map_err(|e| mpay::MppError::Http(format!("Invalid amount: {}", e)))?;
+
+        let evm_config = self
+            .config
+            .require_evm()
+            .map_err(|e| mpay::MppError::Http(e.to_string()))?;
+        let signer = evm_config
+            .load_signer(None)
+            .map_err(|e| mpay::MppError::Http(e.to_string()))?;
+
+        let wallet_address = evm_config
+            .wallet_address
+            .as_ref()
+            .map(|addr| Address::from_str(addr))
+            .transpose()
+            .map_err(|e| mpay::MppError::Http(format!("Invalid wallet address: {}", e)))?;
+
+        let from = wallet_address.unwrap_or_else(|| signer.address());
+
+        let network_name = method_to_network(&challenge.method).ok_or_else(|| {
+            mpay::MppError::UnsupportedPaymentMethod(format!(
+                "Unsupported payment method: {}",
+                challenge.method
+            ))
+        })?;
+        let network = Network::from_str(network_name)
+            .map_err(|e| mpay::MppError::Http(format!("Unknown network: {}", e)))?;
+
+        let balance = query_token_balance(&self.config, network, required_token, from)
             .await
-            .map_err(|e| mpay::MppError::Http(e.to_string()))
+            .map_err(|e| mpay::MppError::Http(e.to_string()))?;
+
+        if balance >= required_amount {
+            return create_tempo_payment(&self.config, challenge)
+                .await
+                .map_err(|e| mpay::MppError::Http(e.to_string()));
+        }
+
+        if self.no_swap {
+            return Err(mpay::MppError::Http(format!(
+                "Insufficient {} balance: have {}, need {}. Use a different token or remove --no-swap to enable automatic swaps.",
+                network.token_config_by_address(&format!("{:#x}", required_token))
+                    .map(|t| t.currency.symbol.to_string())
+                    .unwrap_or_else(|| format!("{:#x}", required_token)),
+                balance,
+                required_amount
+            )));
+        }
+
+        let swap_source =
+            find_swap_source(&self.config, network, from, required_token, required_amount)
+                .await
+                .map_err(|e| mpay::MppError::Http(e.to_string()))?;
+
+        match swap_source {
+            Some(source) => {
+                let target_symbol = network
+                    .token_config_by_address(&format!("{:#x}", required_token))
+                    .map(|t| t.currency.symbol.to_string())
+                    .unwrap_or_else(|| format!("{:#x}", required_token));
+                eprintln!(
+                    "Auto-swapping from {} to {} to complete payment",
+                    source.symbol, target_symbol
+                );
+
+                let swap_info =
+                    SwapInfo::new(source.token_address, required_token, required_amount);
+                create_tempo_payment_with_swap(&self.config, challenge, &swap_info)
+                    .await
+                    .map_err(|e| mpay::MppError::Http(e.to_string()))
+            }
+            None => Err(mpay::MppError::Http(format!(
+                "Insufficient balance and no swap source available. Need {} of {}",
+                required_amount,
+                network
+                    .token_config_by_address(&format!("{:#x}", required_token))
+                    .map(|t| t.currency.symbol.to_string())
+                    .unwrap_or_else(|| format!("{:#x}", required_token))
+            ))),
+        }
     }
 }
 
@@ -159,6 +270,110 @@ pub async fn get_balances(
     }
 
     Ok(balances)
+}
+
+/// Query the balance of a specific token for an account.
+pub async fn query_token_balance(
+    config: &Config,
+    network: Network,
+    token_address: Address,
+    account: Address,
+) -> Result<U256> {
+    let network_info = config.resolve_network(network.as_str())?;
+    let provider =
+        ProviderBuilder::new().connect_http(network_info.rpc_url.parse().map_err(|e| {
+            PgetError::InvalidConfig(format!("Invalid RPC URL for {network}: {e}"))
+        })?);
+
+    let contract = IERC20::new(token_address, &provider);
+    let balance = contract
+        .balanceOf(account)
+        .call()
+        .await
+        .map_err(|e| PgetError::BalanceQuery(format!("Failed to query balance: {}", e)))?;
+
+    Ok(balance)
+}
+
+/// Token with sufficient balance for a swap.
+#[derive(Debug, Clone)]
+pub struct SwapSource {
+    /// Token address that can be used as swap source.
+    pub token_address: Address,
+    /// Current balance of the token.
+    #[allow(dead_code)]
+    pub balance: U256,
+    /// Human-readable symbol.
+    pub symbol: String,
+}
+
+/// Find a token with sufficient balance to swap from.
+///
+/// This queries balances of all supported stablecoins (except the required one)
+/// in parallel and returns the first one with sufficient balance (including slippage).
+///
+/// # Arguments
+/// * `config` - Configuration for RPC access
+/// * `network` - Network to query on
+/// * `account` - Account to check balances for
+/// * `required_token` - The token the merchant wants (we need to find a different one)
+/// * `required_amount` - The amount needed (will include slippage in the check)
+///
+/// # Returns
+/// * `Ok(Some(SwapSource))` - Found a token with sufficient balance
+/// * `Ok(None)` - No token has sufficient balance
+pub async fn find_swap_source(
+    config: &Config,
+    network: Network,
+    account: Address,
+    required_token: Address,
+    required_amount: U256,
+) -> Result<Option<SwapSource>> {
+    use futures::future::join_all;
+
+    let slippage = required_amount * U256::from(SWAP_SLIPPAGE_BPS) / U256::from(BPS_DENOMINATOR);
+    let amount_with_slippage = required_amount + slippage;
+
+    let tokens_to_check: Vec<_> = network
+        .supported_tokens()
+        .into_iter()
+        .filter_map(|token_config| {
+            let token_address = Address::from_str(token_config.address).ok()?;
+            if token_address == required_token {
+                None
+            } else {
+                Some((token_address, token_config.currency.symbol.to_string()))
+            }
+        })
+        .collect();
+
+    let balance_futures: Vec<_> = tokens_to_check
+        .iter()
+        .map(|(token_address, _symbol)| {
+            query_token_balance(config, network, *token_address, account)
+        })
+        .collect();
+
+    let results = join_all(balance_futures).await;
+
+    for ((token_address, symbol), result) in tokens_to_check.into_iter().zip(results) {
+        match result {
+            Ok(balance) => {
+                if balance >= amount_with_slippage {
+                    return Ok(Some(SwapSource {
+                        token_address,
+                        balance,
+                        symbol,
+                    }));
+                }
+            }
+            Err(e) => {
+                eprintln!("Warning: Failed to query {} balance: {}", symbol, e);
+            }
+        }
+    }
+
+    Ok(None)
 }
 
 #[cfg(test)]

--- a/src/payment/providers/tempo.rs
+++ b/src/payment/providers/tempo.rs
@@ -8,8 +8,11 @@
 use crate::config::Config;
 use crate::error::{PgetError, Result, ResultExt, SigningContext};
 use crate::network::{GasConfig, Network};
-use crate::payment::abi::encode_transfer;
-use crate::payment::mpay_ext::{ChargeRequestExt, TempoChargeExt};
+use crate::payment::abi::{
+    encode_approve, encode_swap_exact_amount_out, encode_transfer, DEX_ADDRESS,
+};
+use crate::payment::mpay_ext::TempoChargeExt;
+use crate::wallet::signer::WalletSource;
 use alloy::primitives::{Address, U256};
 use alloy::signers::{local::PrivateKeySigner, SignerSync};
 use std::str::FromStr;
@@ -18,10 +21,146 @@ use tempo_primitives::transaction::{
     AASigned, Call, KeychainSignature, PrimitiveSignature, TempoSignature, TempoTransaction,
 };
 
+/// Gas limit for swap transactions (approve + swap + transfer).
+pub const SWAP_GAS_LIMIT: u64 = 300_000;
+
+/// Parse a hex-encoded memo string to a 32-byte array.
+fn parse_memo(memo_str: Option<String>) -> Option<[u8; 32]> {
+    memo_str.and_then(|s| {
+        let hex_str = s.strip_prefix("0x").unwrap_or(&s);
+        let bytes = hex::decode(hex_str).ok()?;
+        if bytes.len() == 32 {
+            let mut arr = [0u8; 32];
+            arr.copy_from_slice(&bytes);
+            Some(arr)
+        } else {
+            None
+        }
+    })
+}
+
+/// Slippage tolerance in basis points (0.5% = 50 bps).
+pub const SWAP_SLIPPAGE_BPS: u128 = 50;
+
+/// Basis points denominator (10000 bps = 100%).
+pub const BPS_DENOMINATOR: u128 = 10000;
+
+/// Information about a token swap to perform before payment.
+#[derive(Debug, Clone)]
+pub struct SwapInfo {
+    /// Token to swap from (the token the user holds).
+    pub token_in: Address,
+    /// Token to swap to (the token the merchant wants).
+    pub token_out: Address,
+    /// Exact amount of token_out needed.
+    pub amount_out: U256,
+    /// Maximum amount of token_in to spend (includes slippage).
+    pub max_amount_in: U256,
+}
+
+impl SwapInfo {
+    /// Create a new SwapInfo with slippage calculation.
+    ///
+    /// The `max_amount_in` is calculated as `amount_out + (amount_out * SWAP_SLIPPAGE_BPS / BPS_DENOMINATOR)`.
+    pub fn new(token_in: Address, token_out: Address, amount_out: U256) -> Self {
+        // Calculate max_amount_in with slippage: amount_out * (1 + slippage_bps / 10000)
+        let slippage = amount_out * U256::from(SWAP_SLIPPAGE_BPS) / U256::from(BPS_DENOMINATOR);
+        let max_amount_in = amount_out + slippage;
+
+        Self {
+            token_in,
+            token_out,
+            amount_out,
+            max_amount_in,
+        }
+    }
+}
+
 /// Check if a network name refers to a Tempo network.
 #[allow(dead_code)]
 pub fn is_tempo_network(name: &str) -> bool {
     matches!(name.to_lowercase().as_str(), "tempo" | "tempo-moderato")
+}
+
+/// Common context for payment setup, shared between direct and swap payments.
+struct PaymentSetupContext {
+    charge_req: mpay::ChargeRequest,
+    signer: PrivateKeySigner,
+    wallet_address: Option<Address>,
+    from: Address,
+    chain_id: u64,
+    nonce: u64,
+    gas_config: GasConfig,
+}
+
+impl PaymentSetupContext {
+    /// Parse challenge and set up all common payment context.
+    async fn from_challenge(config: &Config, challenge: &mpay::PaymentChallenge) -> Result<Self> {
+        use crate::payment::mpay_ext::method_to_network;
+        use alloy::providers::Provider;
+
+        let charge_req: mpay::ChargeRequest = challenge
+            .request
+            .decode()
+            .map_err(|e| PgetError::InvalidChallenge(format!("Invalid charge request: {}", e)))?;
+
+        let evm_config = config.require_evm()?;
+        let signer = evm_config.load_signer(None)?;
+
+        // If wallet_address is set, use keychain signing mode
+        let wallet_address = evm_config
+            .wallet_address
+            .as_ref()
+            .map(|addr| {
+                Address::from_str(addr)
+                    .map_err(|e| PgetError::InvalidConfig(format!("Invalid wallet address: {}", e)))
+            })
+            .transpose()?;
+
+        let from = wallet_address.unwrap_or_else(|| signer.address());
+
+        let network_name = method_to_network(&challenge.method).ok_or_else(|| {
+            PgetError::UnsupportedPaymentMethod(format!(
+                "Unsupported payment method: {}",
+                challenge.method
+            ))
+        })?;
+
+        let network_info = config.resolve_network(network_name)?;
+        let chain_id = network_info.chain_id.ok_or_else(|| {
+            PgetError::InvalidConfig(format!("{} network missing chain ID", network_name))
+        })?;
+
+        let gas_config = Network::from_str(network_name)
+            .map(|n| n.gas_config())
+            .unwrap_or(GasConfig::DEFAULT);
+
+        let provider = alloy::providers::ProviderBuilder::new().connect_http(
+            network_info.rpc_url.parse().map_err(|e| {
+                PgetError::InvalidConfig(format!("Invalid RPC URL for {}: {}", network_name, e))
+            })?,
+        );
+
+        let nonce = provider
+            .get_transaction_count(from)
+            .pending()
+            .await
+            .with_signing_context(SigningContext {
+                network: Some(network_name.to_string()),
+                address: Some(format!("{:#x}", from)),
+                operation: "get_nonce",
+            })?;
+
+        Ok(Self {
+            charge_req,
+            signer,
+            wallet_address,
+            from,
+            chain_id,
+            nonce,
+            gas_config,
+        })
+    }
 }
 
 /// Create a Tempo payment credential for a Web Payment Auth challenge.
@@ -31,88 +170,121 @@ pub async fn create_tempo_payment(
     config: &Config,
     challenge: &mpay::PaymentChallenge,
 ) -> Result<mpay::PaymentCredential> {
-    use mpay::{ChargeRequest, PaymentCredential, PaymentPayload};
+    let ctx = PaymentSetupContext::from_challenge(config, challenge).await?;
 
-    use crate::payment::mpay_ext::method_to_network;
-    use crate::wallet::signer::WalletSource;
-    use alloy::providers::Provider;
-
-    let charge_req: ChargeRequest = challenge
-        .request
-        .decode()
-        .map_err(|e| PgetError::InvalidChallenge(format!("Invalid charge request: {}", e)))?;
-
-    let evm_config = config.require_evm()?;
-    let signer = evm_config.load_signer(None)?;
-
-    // If wallet_address is set, use keychain signing mode
-    let wallet_address = evm_config
-        .wallet_address
-        .as_ref()
-        .map(|addr| {
-            Address::from_str(addr)
-                .map_err(|e| PgetError::InvalidConfig(format!("Invalid wallet address: {}", e)))
-        })
-        .transpose()?;
-
-    let from = wallet_address.unwrap_or_else(|| signer.address());
-
-    let currency = charge_req.currency_address()?;
-    let recipient = charge_req.recipient_address()?;
-    let amount = charge_req.amount_u256()?;
-    let memo = charge_req.memo();
+    let currency = ctx.charge_req.currency_address()?;
+    let recipient = ctx.charge_req.recipient_address()?;
+    let amount = ctx.charge_req.amount_u256()?;
+    let memo = parse_memo(ctx.charge_req.memo());
 
     let transfer_data = encode_transfer(recipient, amount, memo);
 
-    let network_name = method_to_network(&challenge.method).ok_or_else(|| {
-        PgetError::UnsupportedPaymentMethod(format!(
-            "Unsupported payment method: {}",
-            challenge.method
-        ))
-    })?;
-
-    let network_info = config.resolve_network(network_name)?;
-    let chain_id = network_info.chain_id.ok_or_else(|| {
-        PgetError::InvalidConfig(format!("{} network missing chain ID", network_name))
-    })?;
-
-    let gas_config = Network::from_str(network_name)
-        .map(|n| n.gas_config())
-        .unwrap_or(GasConfig::DEFAULT);
-
-    let provider = alloy::providers::ProviderBuilder::new().connect_http(
-        network_info.rpc_url.parse().map_err(|e| {
-            PgetError::InvalidConfig(format!("Invalid RPC URL for {}: {}", network_name, e))
-        })?,
-    );
-
-    let nonce = provider
-        .get_transaction_count(from)
-        .pending()
-        .await
-        .with_signing_context(SigningContext {
-            network: Some(network_name.to_string()),
-            address: Some(format!("{:#x}", from)),
-            operation: "get_nonce",
-        })?;
-
     let signed_tx = create_tempo_transaction(
-        &signer,
-        chain_id,
-        nonce,
+        &ctx.signer,
+        ctx.chain_id,
+        ctx.nonce,
         currency,
         transfer_data,
-        &gas_config,
-        wallet_address,
+        &ctx.gas_config,
+        ctx.wallet_address,
     )?;
 
-    let did = format!("did:pkh:eip155:{}:{:#x}", chain_id, from);
+    let did = format!("did:pkh:eip155:{}:{:#x}", ctx.chain_id, ctx.from);
 
-    Ok(PaymentCredential {
+    Ok(mpay::PaymentCredential {
         challenge: challenge.to_echo(),
         source: Some(did),
-        payload: PaymentPayload::transaction(format!("0x{}", signed_tx)),
+        payload: mpay::PaymentPayload::transaction(format!("0x{}", signed_tx)),
     })
+}
+
+/// Create a Tempo payment credential with an automatic token swap.
+///
+/// This builds a 3-call atomic transaction:
+/// 1. approve(DEX_ADDRESS, max_amount_in) on token_in
+/// 2. swapExactAmountOut(token_in, token_out, amount_out, max_amount_in) on DEX
+/// 3. transfer(recipient, amount) on token_out
+///
+/// The fee token is set to token_in (the token being swapped from).
+pub async fn create_tempo_payment_with_swap(
+    config: &Config,
+    challenge: &mpay::PaymentChallenge,
+    swap_info: &SwapInfo,
+) -> Result<mpay::PaymentCredential> {
+    let ctx = PaymentSetupContext::from_challenge(config, challenge).await?;
+
+    let recipient = ctx.charge_req.recipient_address()?;
+    let amount = ctx.charge_req.amount_u256()?;
+    let memo = parse_memo(ctx.charge_req.memo());
+
+    // Build the 3-call transaction: approve → swap → transfer
+    let calls = build_swap_calls(swap_info, recipient, amount, memo)?;
+
+    let signed_tx = create_tempo_transaction_with_calls(
+        &ctx.signer,
+        ctx.chain_id,
+        ctx.nonce,
+        swap_info.token_in, // Fee token is the token we're swapping from
+        calls,
+        &ctx.gas_config,
+        SWAP_GAS_LIMIT, // Higher gas limit for swap transactions
+        ctx.wallet_address,
+    )?;
+
+    let did = format!("did:pkh:eip155:{}:{:#x}", ctx.chain_id, ctx.from);
+
+    Ok(mpay::PaymentCredential {
+        challenge: challenge.to_echo(),
+        source: Some(did),
+        payload: mpay::PaymentPayload::transaction(format!("0x{}", signed_tx)),
+    })
+}
+
+/// Build the 3 calls for a swap transaction: approve → swap → transfer.
+fn build_swap_calls(
+    swap_info: &SwapInfo,
+    recipient: Address,
+    amount: U256,
+    memo: Option<[u8; 32]>,
+) -> Result<Vec<Call>> {
+    use alloy::primitives::TxKind;
+
+    // Convert U256 amounts to u128 for the DEX (which uses uint128)
+    let amount_out_u128: u128 = swap_info
+        .amount_out
+        .try_into()
+        .map_err(|_| PgetError::InvalidAmount("Amount too large for u128".to_string()))?;
+    let max_amount_in_u128: u128 = swap_info
+        .max_amount_in
+        .try_into()
+        .map_err(|_| PgetError::InvalidAmount("Max amount too large for u128".to_string()))?;
+
+    let approve_data = encode_approve(DEX_ADDRESS, swap_info.max_amount_in);
+    let swap_data = encode_swap_exact_amount_out(
+        swap_info.token_in,
+        swap_info.token_out,
+        amount_out_u128,
+        max_amount_in_u128,
+    );
+    let transfer_data = encode_transfer(recipient, amount, memo);
+
+    Ok(vec![
+        Call {
+            to: TxKind::Call(swap_info.token_in),
+            value: U256::ZERO,
+            input: approve_data,
+        },
+        Call {
+            to: TxKind::Call(DEX_ADDRESS),
+            value: U256::ZERO,
+            input: swap_data,
+        },
+        Call {
+            to: TxKind::Call(swap_info.token_out),
+            value: U256::ZERO,
+            input: transfer_data,
+        },
+    ])
 }
 
 /// Create a Tempo transaction (type 0x76) with network-specific gas configuration.
@@ -127,17 +299,43 @@ fn create_tempo_transaction(
 ) -> Result<String> {
     use alloy::primitives::TxKind;
 
+    let calls = vec![Call {
+        to: TxKind::Call(asset),
+        value: U256::ZERO,
+        input: transfer_data,
+    }];
+
+    create_tempo_transaction_with_calls(
+        signer,
+        chain_id,
+        nonce,
+        asset,
+        calls,
+        gas_config,
+        gas_config.gas_limit,
+        wallet_address,
+    )
+}
+
+/// Create a Tempo transaction with multiple calls (for swap transactions).
+#[allow(clippy::too_many_arguments)]
+fn create_tempo_transaction_with_calls(
+    signer: &PrivateKeySigner,
+    chain_id: u64,
+    nonce: u64,
+    fee_token: Address,
+    calls: Vec<Call>,
+    gas_config: &GasConfig,
+    gas_limit: u64,
+    wallet_address: Option<Address>,
+) -> Result<String> {
     let tx = TempoTransaction {
         chain_id,
-        fee_token: Some(asset),
+        fee_token: Some(fee_token),
         max_priority_fee_per_gas: gas_config.max_priority_fee_per_gas_u128(),
         max_fee_per_gas: gas_config.max_fee_per_gas_u128(),
-        gas_limit: gas_config.gas_limit,
-        calls: vec![Call {
-            to: TxKind::Call(asset),
-            value: U256::ZERO,
-            input: transfer_data,
-        }],
+        gas_limit,
+        calls,
         access_list: Default::default(),
         nonce_key: U256::ZERO,
         nonce,
@@ -274,5 +472,125 @@ mod tests {
         .unwrap();
 
         assert!(keychain_tx.len() > direct_tx.len());
+    }
+
+    #[test]
+    fn test_swap_info_slippage_calculation() {
+        let token_in: Address = "0x20c0000000000000000000000000000000000001"
+            .parse()
+            .unwrap();
+        let token_out: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+        let amount_out = U256::from(1_000_000u64); // 1 USDC
+
+        let swap_info = SwapInfo::new(token_in, token_out, amount_out);
+
+        // Slippage should be 0.5% = 50 bps = amount * 50 / 10000
+        // 1_000_000 * 50 / 10000 = 5000
+        // max_amount_in = 1_000_000 + 5000 = 1_005_000
+        assert_eq!(swap_info.amount_out, U256::from(1_000_000u64));
+        assert_eq!(swap_info.max_amount_in, U256::from(1_005_000u64));
+    }
+
+    #[test]
+    fn test_swap_info_slippage_with_large_amount() {
+        let token_in = Address::ZERO;
+        let token_out = Address::repeat_byte(0x01);
+        // 1 billion (1e9 with 6 decimals = 1000 USD)
+        let amount_out = U256::from(1_000_000_000u64);
+
+        let swap_info = SwapInfo::new(token_in, token_out, amount_out);
+
+        // Slippage: 1_000_000_000 * 50 / 10000 = 5_000_000
+        // max_amount_in = 1_000_000_000 + 5_000_000 = 1_005_000_000
+        assert_eq!(swap_info.max_amount_in, U256::from(1_005_000_000u64));
+    }
+
+    #[test]
+    fn test_swap_info_preserves_addresses() {
+        let token_in: Address = "0x20c0000000000000000000000000000000000001"
+            .parse()
+            .unwrap();
+        let token_out: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+        let amount_out = U256::from(100u64);
+
+        let swap_info = SwapInfo::new(token_in, token_out, amount_out);
+
+        assert_eq!(swap_info.token_in, token_in);
+        assert_eq!(swap_info.token_out, token_out);
+    }
+
+    #[test]
+    fn test_swap_slippage_bps_constant() {
+        // Verify slippage is 50 bps (0.5%)
+        assert_eq!(SWAP_SLIPPAGE_BPS, 50);
+    }
+
+    #[test]
+    fn test_swap_gas_limit_constant() {
+        // Verify gas limit is 300,000 for swap transactions
+        assert_eq!(SWAP_GAS_LIMIT, 300_000);
+        // Should be higher than default gas limit
+        assert!(SWAP_GAS_LIMIT > GasConfig::DEFAULT.gas_limit);
+    }
+
+    #[test]
+    fn test_build_swap_calls_produces_three_calls() {
+        use crate::payment::abi::DEX_ADDRESS;
+
+        let token_in: Address = "0x20c0000000000000000000000000000000000001"
+            .parse()
+            .unwrap();
+        let token_out: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+        let recipient: Address = "0x1234567890123456789012345678901234567890"
+            .parse()
+            .unwrap();
+        let amount = U256::from(1_000_000u64);
+
+        let swap_info = SwapInfo::new(token_in, token_out, amount);
+        let calls = build_swap_calls(&swap_info, recipient, amount, None).unwrap();
+
+        // Should produce exactly 3 calls
+        assert_eq!(calls.len(), 3);
+
+        // Call 1: approve on token_in
+        assert_eq!(calls[0].to.to().unwrap(), &token_in);
+
+        // Call 2: swap on DEX
+        assert_eq!(calls[1].to.to().unwrap(), &DEX_ADDRESS);
+
+        // Call 3: transfer on token_out
+        assert_eq!(calls[2].to.to().unwrap(), &token_out);
+
+        // All calls should have zero value
+        assert!(calls.iter().all(|c| c.value == U256::ZERO));
+    }
+
+    #[test]
+    fn test_build_swap_calls_with_memo() {
+        let token_in = Address::repeat_byte(0x01);
+        let token_out = Address::repeat_byte(0x02);
+        let recipient = Address::repeat_byte(0x03);
+        let amount = U256::from(500_000u64);
+        let memo = Some([0xab; 32]);
+
+        let swap_info = SwapInfo::new(token_in, token_out, amount);
+        let calls = build_swap_calls(&swap_info, recipient, amount, memo).unwrap();
+
+        // Should still produce 3 calls with memo
+        assert_eq!(calls.len(), 3);
+        // Transfer call (3rd) should have different data than without memo
+        assert!(!calls[2].input.is_empty());
+    }
+
+    #[test]
+    fn test_bps_denominator_constant() {
+        // Verify BPS denominator is 10000
+        assert_eq!(BPS_DENOMINATOR, 10000);
     }
 }

--- a/src/payment/web_payment.rs
+++ b/src/payment/web_payment.rs
@@ -133,7 +133,7 @@ pub async fn handle_web_payment_request(
     }
 
     // Use mpay::client::PaymentProvider to create the credential
-    let provider = PgetPaymentProvider::new(config.clone());
+    let provider = PgetPaymentProvider::with_no_swap(config.clone(), request_ctx.cli.no_swap);
 
     if request_ctx.cli.is_verbose() && request_ctx.cli.should_show_output() {
         eprintln!("Creating payment credential...");


### PR DESCRIPTION
## Summary

  - Add automatic token swapping when user doesn't have the merchant's requested stablecoin
  - Swaps are executed atomically via the Tempo StablecoinDEX (approve → swap → transfer in one transaction)
  - Add --no-swap flag to disable automatic swapping

  ## Changes

  - Add --no-swap CLI flag and PGET_NO_SWAP env var
  - Add swap ABI encoding (encode_approve, encode_swap_exact_amount_out)
  - Add balance queries and swap source detection with parallel queries
  - Add create_tempo_payment_with_swap for atomic 3-call transactions
  - 0.5% slippage tolerance, 300k gas limit for swap transactions
  - Update README with documentation on automatic token swapping