### PR TITLE
chore: disable crates.io publish until tempo-primitives is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,17 +132,18 @@ jobs:
           echo "Uploaded ${VERSION} binaries to R2"
 
   # Publish to crates.io on tag or workflow_call
-  publish:
-    name: Publish to crates.io
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v') || inputs.version
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Configure git for private repos
-        run: git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Publish to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --no-verify
+  # DISABLED: tempo-primitives not yet published to crates.io (git deps not allowed)
+  # publish:
+  #   name: Publish to crates.io
+  #   needs: build
+  #   if: startsWith(github.ref, 'refs/tags/v') || inputs.version
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Configure git for private repos
+  #       run: git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
+  #     - uses: dtolnay/rust-toolchain@stable
+  #     - name: Publish to crates.io
+  #       env:
+  #         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  #       run: cargo publish --no-verify


### PR DESCRIPTION
The `tempo-primitives` crate on crates.io is currently a placeholder (v0.0.0). Since we depend on it via git, `cargo publish` will fail.

This disables the crates.io publish job in the release workflow until tempo-primitives is properly published.