### PR TITLE
fix: create config.toml during wallet init flow

### DIFF
--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -21,6 +21,12 @@ async fn run_wallet_init(skip_ai: bool) -> Result<()> {
     let manager = WalletManager::new(None);
     manager.setup_wallet().await?;
 
+    let config_path = Config::default_config_path()?;
+    if !config_path.exists() {
+        let config = Config::default();
+        config.save().context("Failed to save configuration")?;
+    }
+
     println!("\nTempo wallet connected! You can now make HTTP payments.");
 
     if !skip_ai {


### PR DESCRIPTION
## Problem

`pget init` (passkey flow) creates `wallet.toml` but not `config.toml`. Subsequent `pget <url>` calls fail with "Config file not found" because `Config::load_from` requires it.

## Fix

`run_wallet_init` now creates a default `config.toml` if one doesn't already exist, matching what the keystore init flow already does.

## Changes

- **src/cli/commands/init.rs**: Create default `config.toml` after successful wallet connect

## Testing

`make check` passes (fmt, clippy, 411 tests, build).