### PR TITLE
fix: remove strict realm origin validation

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -112,7 +112,7 @@ pub struct QueryArgs {
     )]
     pub no_swap: bool,
 
-    /// Allow insecure operations (skip TLS verification and origin checks)
+    /// Allow insecure operations (skip TLS verification)
     #[arg(short = 'k', long = "insecure", help_heading = "Request Options")]
     pub insecure: bool,
 

--- a/src/payment/web_payment.rs
+++ b/src/payment/web_payment.rs
@@ -2,14 +2,8 @@
 //!
 //! This module handles the IETF Web Payment Auth protocol (draft-ietf-httpauth-payment-01)
 //! which uses WWW-Authenticate and Authorization headers for blockchain payments.
-//!
-//! # Security Model
-//!
-//! Origin validation ensures the challenge `realm` matches the request host,
-//! preventing malicious servers from returning payment challenges for different origins.
 
 use anyhow::{Context, Result};
-use reqwest::Url;
 use std::str::FromStr;
 
 use mpay::{parse_receipt, parse_www_authenticate, ChargeRequest, PaymentChallenge};
@@ -26,49 +20,7 @@ use crate::network::Network;
 use crate::payment::mpay_ext::{method_to_network, validate_challenge};
 use crate::payment::provider::PgetPaymentProvider;
 
-/// Validate that the challenge realm matches the request origin.
-///
-/// # Security
-///
-/// This prevents a malicious server from returning a challenge for a different
-/// origin, which could trick the client into making a payment to an unintended
-/// recipient. The realm should match the host of the original request.
-fn validate_origin(url: &str, challenge: &PaymentChallenge, skip_check: bool) -> Result<()> {
-    if skip_check {
-        return Ok(());
-    }
-
-    let parsed_url = Url::parse(url).context("Failed to parse request URL")?;
-    let request_host = parsed_url
-        .host_str()
-        .ok_or_else(|| anyhow::anyhow!("Request URL has no host"))?;
-
-    let realm_lower = challenge.realm.to_lowercase();
-    let host_lower = request_host.to_lowercase();
-
-    let is_valid = realm_lower == host_lower
-        || realm_lower.ends_with(&format!(".{}", host_lower))
-        || host_lower.ends_with(&format!(".{}", realm_lower));
-
-    if !is_valid {
-        anyhow::bail!(
-            "Payment challenge realm '{}' does not match request host '{}'. \
-             This could indicate a malicious server. \
-             Use --insecure to bypass (DANGEROUS).",
-            challenge.realm,
-            request_host
-        );
-    }
-
-    Ok(())
-}
-
 /// Handle Web Payment Auth protocol (402 with WWW-Authenticate: Payment header)
-///
-/// # Security Requirements
-///
-/// - Origin validation ensures challenge realm matches request host
-/// - Additional constraints from CLI flags (max-amount, network) are enforced
 pub async fn handle_web_payment_request(
     config: &Config,
     request_ctx: &RequestContext,
@@ -81,9 +33,6 @@ pub async fn handle_web_payment_request(
 
     let challenge =
         parse_www_authenticate(www_auth).context("Failed to parse WWW-Authenticate header")?;
-
-    // SECURITY: Validate origin before proceeding
-    validate_origin(url, &challenge, request_ctx.query.insecure)?;
 
     // Get network and explorer config early for clickable links
     let network = method_to_network(&challenge.method)
@@ -269,11 +218,7 @@ mod tests {
     use clap::Parser;
     use mpay::{MethodName, PaymentChallenge};
 
-    fn mock_challenge_with_realm(
-        method: MethodName,
-        amount: &str,
-        realm: &str,
-    ) -> (PaymentChallenge, ChargeRequest) {
+    fn mock_challenge(method: MethodName, amount: &str) -> (PaymentChallenge, ChargeRequest) {
         use mpay::Base64UrlJson;
 
         let charge_req = ChargeRequest {
@@ -288,7 +233,7 @@ mod tests {
 
         let challenge = PaymentChallenge {
             id: "test-challenge-id".to_string(),
-            realm: realm.to_string(),
+            realm: "api.example.com".to_string(),
             method,
             intent: "charge".into(),
             request: Base64UrlJson::from_typed(&charge_req).expect("serialize charge request"),
@@ -300,71 +245,8 @@ mod tests {
         (challenge, charge_req)
     }
 
-    fn mock_challenge(method: MethodName, amount: &str) -> (PaymentChallenge, ChargeRequest) {
-        mock_challenge_with_realm(method, amount, "api.example.com")
-    }
-
     fn default_query() -> QueryArgs {
         make_query_args(&["query", "http://example.com"])
-    }
-
-    #[test]
-    fn test_validate_origin_exact_match() {
-        let (challenge, _) =
-            mock_challenge_with_realm(MethodName::new("tempo"), "1000000", "api.example.com");
-        let result = validate_origin("https://api.example.com/pay", &challenge, false);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_validate_origin_case_insensitive() {
-        let (challenge, _) =
-            mock_challenge_with_realm(MethodName::new("tempo"), "1000000", "API.EXAMPLE.COM");
-        let result = validate_origin("https://api.example.com/pay", &challenge, false);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_validate_origin_subdomain_of_realm() {
-        let (challenge, _) =
-            mock_challenge_with_realm(MethodName::new("tempo"), "1000000", "example.com");
-        let result = validate_origin("https://api.example.com/pay", &challenge, false);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_validate_origin_realm_is_subdomain() {
-        let (challenge, _) =
-            mock_challenge_with_realm(MethodName::new("tempo"), "1000000", "api.example.com");
-        let result = validate_origin("https://example.com/pay", &challenge, false);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_validate_origin_mismatch() {
-        let (challenge, _) =
-            mock_challenge_with_realm(MethodName::new("tempo"), "1000000", "evil.com");
-        let result = validate_origin("https://api.example.com/pay", &challenge, false);
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("does not match request host"));
-        assert!(err.contains("evil.com"));
-    }
-
-    #[test]
-    fn test_validate_origin_skip_check() {
-        let (challenge, _) =
-            mock_challenge_with_realm(MethodName::new("tempo"), "1000000", "evil.com");
-        let result = validate_origin("https://api.example.com/pay", &challenge, true);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_validate_origin_partial_match_rejected() {
-        let (challenge, _) =
-            mock_challenge_with_realm(MethodName::new("tempo"), "1000000", "example.com");
-        let result = validate_origin("https://notexample.com/pay", &challenge, false);
-        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
The `validate_origin` check was overeager and stricter than the Web Payment Auth spec, which follows Basic Auth realm semantics. Realms are informational identifiers (useful for e.g. concurrent streams), not security boundaries that must match the request host.

This caused false positives when the realm (e.g. `mpp.dev`) didn't match the request host (e.g. `mpp.tempo.xyz`), requiring `--insecure` to bypass.

**Changes:**
- Remove `validate_origin()` function and its call in `handle_web_payment_request`
- Remove all origin validation tests
- Remove `reqwest::Url` import (no longer needed)
- Update `--insecure` help text to remove mention of origin checks

Context: https://tempoxyz.slack.com/archives/C0A8YB63Q91/p1770325326839669