### PR TITLE
fix: bump gas limit from 300k to 500k for AA transactions

### DIFF
--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -71,7 +71,7 @@ pub struct TokenConfig {
 /// Gas configuration for EVM networks.
 #[derive(Debug, Clone, Copy)]
 pub struct GasConfig {
-    /// Default gas limit for token transfers (100,000 gas).
+    /// Default gas limit for token transfers (500,000 gas).
     pub gas_limit: u64,
     /// Maximum priority fee per gas in wei (1 gwei).
     pub max_priority_fee_per_gas: u64,
@@ -82,7 +82,7 @@ pub struct GasConfig {
 impl GasConfig {
     /// Default gas configuration for Tempo networks.
     pub const DEFAULT: Self = Self {
-        gas_limit: 300_000,
+        gas_limit: 500_000,
         max_priority_fee_per_gas: 1_000_000_000, // 1 gwei
         max_fee_per_gas: 20_000_000_000,         // 20 gwei
     };
@@ -371,7 +371,7 @@ mod tests {
     #[test]
     fn test_gas_config() {
         let gas = Network::Tempo.gas_config();
-        assert_eq!(gas.gas_limit, 300_000);
+        assert_eq!(gas.gas_limit, 500_000);
         assert_eq!(gas.max_priority_fee_per_gas, 1_000_000_000);
         assert_eq!(gas.max_fee_per_gas, 20_000_000_000);
     }

--- a/src/payment/providers/tempo.rs
+++ b/src/payment/providers/tempo.rs
@@ -23,7 +23,7 @@ use tempo_primitives::transaction::{
 };
 
 /// Gas limit for swap transactions (approve + swap + transfer).
-pub const SWAP_GAS_LIMIT: u64 = 300_000;
+pub const SWAP_GAS_LIMIT: u64 = 500_000;
 
 /// Parse a hex-encoded memo string to a 32-byte array.
 fn parse_memo(memo_str: Option<String>) -> Option<[u8; 32]> {
@@ -597,8 +597,8 @@ mod tests {
 
     #[test]
     fn test_swap_gas_limit_constant() {
-        // Verify gas limit is 300,000 for swap transactions
-        assert_eq!(SWAP_GAS_LIMIT, 300_000);
+        // Verify gas limit is 500,000 for swap transactions
+        assert_eq!(SWAP_GAS_LIMIT, 500_000);
         // Should be at least the default gas limit
         assert!(SWAP_GAS_LIMIT >= GasConfig::DEFAULT.gas_limit);
     }


### PR DESCRIPTION
## Summary
Bump default and swap gas limits from 300,000 to 500,000 to fix AA transaction broadcast failures.

## Motivation
AA transactions with key authorizations have intrinsic gas exceeding 300k (observed: 334,272), causing `Insufficient gas for AA transaction` RPC errors.

## Changes
- `src/network/types.rs`: Default `GasConfig::gas_limit` 300k → 500k
- `src/payment/providers/tempo.rs`: `SWAP_GAS_LIMIT` 300k → 500k
- Updated corresponding tests and comments

## Testing
`make check` — all 337 tests pass, clippy clean.