### PR TITLE
feat: add centralized analytics with posthog-rs SDK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ dialoguer = "0.12"
 dirs = "6.0"
 futures = "0.3"
 hex = "0.4"
+hostname = "0.4"
+posthog-rs = "0.3.5"
 mpay = { git = "https://github.com/tempoxyz/mpay-rs.git", branch = "main", features = ["tempo", "evm", "utils", "client"] }
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }

--- a/src/analytics/events.rs
+++ b/src/analytics/events.rs
@@ -1,0 +1,180 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Event {
+    LoginStarted,
+    LoginSuccess,
+    LoginFailure,
+    Logout,
+
+    QueryStarted,
+    QuerySuccess,
+    QueryFailure,
+
+    PaymentStarted,
+    PaymentSuccess,
+    PaymentFailure,
+
+    BalanceChecked,
+    WalletRefreshed,
+
+    KeyCreated,
+    KeySwitched,
+    KeyDeleted,
+    KeysListed,
+
+    CallbackWindowOpened,
+    CallbackReceived,
+
+    SessionStarted,
+    CommandRun,
+}
+
+impl Event {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::LoginStarted => "login_started",
+            Self::LoginSuccess => "login_success",
+            Self::LoginFailure => "login_failure",
+            Self::Logout => "logout",
+            Self::QueryStarted => "query_started",
+            Self::QuerySuccess => "query_success",
+            Self::QueryFailure => "query_failure",
+            Self::PaymentStarted => "payment_started",
+            Self::PaymentSuccess => "payment_success",
+            Self::PaymentFailure => "payment_failure",
+            Self::BalanceChecked => "balance_checked",
+            Self::WalletRefreshed => "wallet_refreshed",
+            Self::KeyCreated => "key_created",
+            Self::KeySwitched => "key_switched",
+            Self::KeyDeleted => "key_deleted",
+            Self::KeysListed => "keys_listed",
+            Self::CallbackWindowOpened => "callback_window_opened",
+            Self::CallbackReceived => "callback_received",
+            Self::SessionStarted => "session_started",
+            Self::CommandRun => "command_run",
+        }
+    }
+}
+
+pub trait EventPayload: Serialize + Send + Sync + 'static {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EmptyPayload;
+impl EventPayload for EmptyPayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LoginPayload {
+    pub network: String,
+}
+impl EventPayload for LoginPayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LoginFailurePayload {
+    pub network: String,
+    pub error: String,
+}
+impl EventPayload for LoginFailurePayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct QueryStartedPayload {
+    pub url: String,
+    pub method: String,
+}
+impl EventPayload for QueryStartedPayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct QuerySuccessPayload {
+    pub url: String,
+    pub method: String,
+    pub status_code: u32,
+}
+impl EventPayload for QuerySuccessPayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct QueryFailurePayload {
+    pub url: String,
+    pub method: String,
+    pub error: String,
+}
+impl EventPayload for QueryFailurePayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PaymentStartedPayload {
+    pub network: String,
+    pub amount: String,
+    pub currency: String,
+}
+impl EventPayload for PaymentStartedPayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PaymentSuccessPayload {
+    pub network: String,
+    pub amount: String,
+    pub currency: String,
+    pub tx_hash: String,
+}
+impl EventPayload for PaymentSuccessPayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PaymentFailurePayload {
+    pub network: String,
+    pub amount: String,
+    pub currency: String,
+    pub error: String,
+}
+impl EventPayload for PaymentFailurePayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BalanceCheckedPayload {
+    pub network: String,
+}
+impl EventPayload for BalanceCheckedPayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CommandRunPayload {
+    pub command: String,
+}
+impl EventPayload for CommandRunPayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionStartedPayload {
+    pub is_new_user: bool,
+    pub command: String,
+}
+impl EventPayload for SessionStartedPayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct KeyCreatedPayload {
+    pub network: String,
+    pub label: String,
+}
+impl EventPayload for KeyCreatedPayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct KeySwitchedPayload {
+    pub index: usize,
+    pub label: String,
+}
+impl EventPayload for KeySwitchedPayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct KeyDeletedPayload {
+    pub index: usize,
+    pub label: String,
+}
+impl EventPayload for KeyDeletedPayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CallbackWindowOpenedPayload {
+    pub is_refresh: bool,
+    pub network: String,
+}
+impl EventPayload for CallbackWindowOpenedPayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CallbackReceivedPayload {
+    pub network: String,
+    pub duration_secs: u64,
+}
+impl EventPayload for CallbackReceivedPayload {}

--- a/src/analytics/mod.rs
+++ b/src/analytics/mod.rs
@@ -1,0 +1,126 @@
+mod events;
+mod posthog;
+
+pub use events::*;
+
+use std::sync::{Arc, Mutex};
+
+use serde_json::{json, Value};
+use tokio::task::JoinHandle;
+use tokio::time::{timeout, Duration};
+
+fn is_telemetry_disabled() -> bool {
+    std::env::var("TEMPOCTL_NO_TELEMETRY").is_ok()
+}
+
+fn get_wallet_address() -> Option<String> {
+    use crate::wallet::credentials::WalletCredentials;
+
+    let creds = WalletCredentials::load().ok()?;
+    let wallet = creds.active_wallet()?;
+    if wallet.account_address.is_empty() {
+        None
+    } else {
+        Some(wallet.account_address.clone())
+    }
+}
+
+fn anonymous_id() -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    if let Ok(name) = hostname::get() {
+        name.hash(&mut hasher);
+    }
+    format!("anon-{:016x}", hasher.finish())
+}
+
+#[derive(Clone)]
+pub struct Analytics {
+    client: Arc<posthog_rs::Client>,
+    distinct_id: String,
+    network: Option<String>,
+    pending: Arc<Mutex<Vec<JoinHandle<()>>>>,
+}
+
+impl Analytics {
+    pub async fn new(network: Option<&str>) -> Option<Self> {
+        if is_telemetry_disabled() {
+            return None;
+        }
+
+        let client = posthog::build_client().await?;
+        let distinct_id = get_wallet_address().unwrap_or_else(anonymous_id);
+
+        Some(Self {
+            client: Arc::new(client),
+            distinct_id,
+            network: network.map(|s| s.to_string()),
+            pending: Arc::new(Mutex::new(Vec::new())),
+        })
+    }
+
+    pub fn track<P: EventPayload>(&self, event: Event, payload: P) {
+        let client = self.client.clone();
+        let distinct_id = self.distinct_id.clone();
+        let event_name = event.as_str().to_string();
+        let network = self.network.clone();
+
+        let mut props = serde_json::to_value(&payload).unwrap_or_default();
+        if let Some(ref net) = network {
+            if let Value::Object(ref mut map) = props {
+                map.entry("network".to_string()).or_insert(json!(net));
+            }
+        }
+
+        let handle = tokio::spawn(async move {
+            posthog::capture(&client, &distinct_id, &event_name, props).await;
+        });
+        if let Ok(mut pending) = self.pending.lock() {
+            pending.push(handle);
+        }
+    }
+
+    pub fn identify(&self) {
+        let Some(wallet) = get_wallet_address() else {
+            return;
+        };
+
+        let client = self.client.clone();
+        let old_id = self.distinct_id.clone();
+        let network = self.network.clone();
+
+        let handle = tokio::spawn(async move {
+            if old_id != wallet {
+                posthog::alias(&client, &old_id, &wallet).await;
+            }
+            posthog::identify(
+                &client,
+                &wallet,
+                json!({
+                    "wallet_address": &wallet,
+                    "cli_version": env!("CARGO_PKG_VERSION"),
+                    "os": std::env::consts::OS,
+                    "arch": std::env::consts::ARCH,
+                    "network": network,
+                }),
+            )
+            .await;
+        });
+        if let Ok(mut pending) = self.pending.lock() {
+            pending.push(handle);
+        }
+    }
+
+    pub async fn flush(&self) {
+        let handles = {
+            let mut pending = self.pending.lock().unwrap_or_else(|e| e.into_inner());
+            std::mem::take(&mut *pending)
+        };
+
+        for handle in handles {
+            let _ = timeout(Duration::from_secs(1), handle).await;
+        }
+    }
+}

--- a/src/analytics/posthog.rs
+++ b/src/analytics/posthog.rs
@@ -1,0 +1,45 @@
+use posthog_rs::{Client, Event};
+use serde_json::Value;
+
+const POSTHOG_API_KEY: &str = "phc_aNlTw2xAUQKd9zTovXeYheEUpQpEhplehCK5r1e31HR";
+
+pub async fn build_client() -> Option<Client> {
+    Some(posthog_rs::client(POSTHOG_API_KEY).await)
+}
+
+fn add_common_props(event: &mut Event) {
+    let _ = event.insert_prop("tempo_app_id", "tempoctl");
+    let _ = event.insert_prop("$lib", "tempoctl");
+    let _ = event.insert_prop("$lib_version", env!("CARGO_PKG_VERSION"));
+    let _ = event.insert_prop("os", std::env::consts::OS);
+    let _ = event.insert_prop("arch", std::env::consts::ARCH);
+}
+
+pub async fn capture(client: &Client, distinct_id: &str, event_name: &str, properties: Value) {
+    let mut event = Event::new(event_name, distinct_id);
+    add_common_props(&mut event);
+
+    if let Value::Object(map) = properties {
+        for (k, v) in map {
+            let _ = event.insert_prop(k, v);
+        }
+    }
+
+    let _ = client.capture(event).await;
+}
+
+pub async fn alias(client: &Client, previous_id: &str, new_id: &str) {
+    let mut event = Event::new("$create_alias", new_id);
+    let _ = event.insert_prop("alias", previous_id);
+    let _ = event.insert_prop("tempo_app_id", "tempoctl");
+
+    let _ = client.capture(event).await;
+}
+
+pub async fn identify(client: &Client, distinct_id: &str, properties: Value) {
+    let mut event = Event::new("$identify", distinct_id);
+    let _ = event.insert_prop("tempo_app_id", "tempoctl");
+    let _ = event.insert_prop("$set", properties);
+
+    let _ = client.capture(event).await;
+}

--- a/src/cli/commands/keys.rs
+++ b/src/cli/commands/keys.rs
@@ -110,7 +110,7 @@ pub async fn switch_key(
     index: usize,
     output_format: OutputFormat,
     network: Option<&str>,
-) -> Result<()> {
+) -> Result<Option<String>> {
     let mut creds = WalletCredentials::load()?;
     if let Some(n) = network {
         creds.network = n.to_string();
@@ -130,7 +130,7 @@ pub async fn switch_key(
         match output_format {
             OutputFormat::Json => {
                 println!("{}", serde_json::json!({"error": err_msg}));
-                return Ok(());
+                return Ok(None);
             }
             _ => return Err(TempoCtlError::InvalidConfig(err_msg)),
         }
@@ -158,7 +158,7 @@ pub async fn switch_key(
         }
     }
 
-    Ok(())
+    Ok(Some(label))
 }
 
 /// Delete an access key.
@@ -166,7 +166,7 @@ pub async fn delete_key(
     index: usize,
     output_format: OutputFormat,
     network: Option<&str>,
-) -> Result<()> {
+) -> Result<Option<String>> {
     let mut creds = WalletCredentials::load()?;
     if let Some(n) = network {
         creds.network = n.to_string();
@@ -188,13 +188,14 @@ pub async fn delete_key(
             match output_format {
                 OutputFormat::Json => {
                     println!("{}", serde_json::json!({"error": err_msg}));
-                    return Ok(());
+                    return Ok(None);
                 }
                 _ => return Err(TempoCtlError::InvalidConfig(err_msg)),
             }
         }
     };
 
+    let label = key.label.clone();
     creds.save()?;
 
     match output_format {
@@ -216,5 +217,5 @@ pub async fn delete_key(
         }
     }
 
-    Ok(())
+    Ok(Some(label))
 }

--- a/src/cli/commands/login.rs
+++ b/src/cli/commands/login.rs
@@ -1,3 +1,4 @@
+use crate::analytics::Analytics;
 use crate::config::Config;
 use crate::wallet::WalletManager;
 use anyhow::{Context, Result};
@@ -5,10 +6,10 @@ use std::path::PathBuf;
 
 const TEMPOCTL_SKILL_CONTENT: &str = include_str!("../../../.ai/skills/tempoctl/SKILL.md");
 
-pub async fn run_login(network: Option<&str>) -> Result<()> {
+pub async fn run_login(network: Option<&str>, analytics: Option<Analytics>) -> Result<()> {
     println!("Connecting your Tempo wallet...");
 
-    let manager = WalletManager::new(network);
+    let manager = WalletManager::new(network, analytics);
     manager.setup_wallet().await?;
 
     let config_path = Config::default_config_path()?;

--- a/src/cli/commands/tempo_wallet.rs
+++ b/src/cli/commands/tempo_wallet.rs
@@ -1,5 +1,6 @@
 //! Tempo wallet commands (passkey-based authentication).
 
+use crate::analytics::Analytics;
 use crate::error::{Result, TempoCtlError};
 use crate::network::get_network;
 use crate::util::constants::{BALANCE_OF_SELECTOR, BUILTIN_TOKENS};
@@ -15,7 +16,7 @@ pub struct TokenBalance {
 }
 
 /// Refresh the access key for the current wallet.
-pub async fn refresh_wallet(network: Option<&str>) -> Result<()> {
+pub async fn refresh_wallet(network: Option<&str>, analytics: Option<Analytics>) -> Result<()> {
     let mut creds = WalletCredentials::load()?;
     if let Some(n) = network {
         creds.network = n.to_string();
@@ -26,7 +27,7 @@ pub async fn refresh_wallet(network: Option<&str>) -> Result<()> {
     })?;
 
     let account_address = wallet.account_address.clone();
-    let manager = WalletManager::new(Some(&creds.network));
+    let manager = WalletManager::new(Some(&creds.network), analytics);
     manager.refresh_access_key(&account_address).await
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 //! tempoctl CLI - A wget-like tool for payment-enabled HTTP requests
 
 // Library modules (from lib.rs)
+mod analytics;
 mod config;
 mod error;
 mod http;
@@ -29,6 +30,7 @@ use cli::{
 use colored::control;
 use std::path::PathBuf;
 
+use analytics::Analytics;
 use cli::output::{handle_regular_response, write_output};
 use config::{load_config, load_config_with_overrides};
 use http::request::RequestContext;
@@ -72,16 +74,89 @@ async fn run() -> Result<()> {
 
 /// Handle CLI subcommands
 async fn handle_command(cli: Cli, command: Commands) -> Result<()> {
-    match command {
-        Commands::Query(query) => make_request(cli, *query).await,
+    let analytics = Analytics::new(cli.network.as_deref()).await;
+
+    if let Some(ref a) = analytics {
+        a.identify();
+
+        let is_new_user = wallet::credentials::WalletCredentials::load()
+            .ok()
+            .and_then(|c| c.active_wallet().cloned())
+            .is_none();
+
+        let cmd_name = match &command {
+            Commands::Query(_) => "query",
+            Commands::Login => "login",
+            Commands::Logout { .. } => "logout",
+            Commands::Config { .. } => "config",
+            Commands::Version => "version",
+            Commands::Completions { .. } => "completions",
+            Commands::Balance { .. } => "balance",
+            Commands::Networks { .. } => "networks",
+            Commands::Inspect { .. } => "inspect",
+            Commands::Wallet { .. } => "wallet",
+            Commands::Keys { .. } => "keys",
+            Commands::Services { .. } => "services",
+            Commands::Whoami { .. } => "whoami",
+        };
+        a.track(
+            analytics::Event::SessionStarted,
+            analytics::SessionStartedPayload {
+                is_new_user,
+                command: cmd_name.to_string(),
+            },
+        );
+        a.track(
+            analytics::Event::CommandRun,
+            analytics::CommandRunPayload {
+                command: cmd_name.to_string(),
+            },
+        );
+    }
+
+    let result = match command {
+        Commands::Query(query) => make_request(cli, *query, analytics.clone()).await,
 
         Commands::Login => {
             let network = cli.network.as_deref();
-            cli::commands::login::run_login(network).await
+            if let Some(ref a) = analytics {
+                a.track(
+                    analytics::Event::LoginStarted,
+                    analytics::LoginPayload {
+                        network: network.unwrap_or("tempo-moderato").to_string(),
+                    },
+                );
+            }
+            let result = cli::commands::login::run_login(network, analytics.clone()).await;
+            if let Some(ref a) = analytics {
+                match &result {
+                    Ok(()) => {
+                        a.track(
+                            analytics::Event::LoginSuccess,
+                            analytics::LoginPayload {
+                                network: network.unwrap_or("tempo-moderato").to_string(),
+                            },
+                        );
+                    }
+                    Err(e) => {
+                        a.track(
+                            analytics::Event::LoginFailure,
+                            analytics::LoginFailurePayload {
+                                network: network.unwrap_or("tempo-moderato").to_string(),
+                                error: e.to_string(),
+                            },
+                        );
+                    }
+                }
+            }
+            result
         }
 
         Commands::Logout { yes } => {
             let network = cli.network.as_deref();
+            if let Some(ref a) = analytics {
+                a.track(analytics::Event::Logout, analytics::EmptyPayload);
+            }
             cli::commands::logout::run_logout(yes, network).await
         }
 
@@ -107,6 +182,14 @@ async fn handle_command(cli: Cli, command: Commands) -> Result<()> {
 
         Commands::Balance { address } => {
             let config = load_config(cli.config.as_ref())?;
+            if let Some(ref a) = analytics {
+                a.track(
+                    analytics::Event::BalanceChecked,
+                    analytics::BalanceCheckedPayload {
+                        network: cli.network.clone().unwrap_or_default(),
+                    },
+                );
+            }
             cli::commands::balance::balance_command(&config, address, cli.network.clone()).await
         }
 
@@ -139,9 +222,17 @@ async fn handle_command(cli: Cli, command: Commands) -> Result<()> {
         Commands::Wallet { command } => {
             let network = cli.network.as_deref();
             match command {
-                WalletCommands::Refresh => cli::commands::tempo_wallet::refresh_wallet(network)
-                    .await
-                    .map_err(Into::into),
+                WalletCommands::Refresh => {
+                    let result =
+                        cli::commands::tempo_wallet::refresh_wallet(network, analytics.clone())
+                            .await;
+                    if let Some(ref a) = analytics {
+                        if result.is_ok() {
+                            a.track(analytics::Event::WalletRefreshed, analytics::EmptyPayload);
+                        }
+                    }
+                    result.map_err(Into::into)
+                }
             }
         }
 
@@ -153,22 +244,50 @@ async fn handle_command(cli: Cli, command: Commands) -> Result<()> {
             if let Some(subcommand) = command {
                 match subcommand {
                     cli::KeysCommands::List => {
+                        if let Some(ref a) = analytics {
+                            a.track(analytics::Event::KeysListed, analytics::EmptyPayload);
+                        }
                         cli::commands::keys::list_keys(output_format, network)
                             .await
                             .map_err(Into::into)
                     }
                     cli::KeysCommands::Switch { index } => {
-                        cli::commands::keys::switch_key(index, output_format, network)
-                            .await
-                            .map_err(Into::into)
+                        let result =
+                            cli::commands::keys::switch_key(index, output_format, network).await;
+                        if let Some(ref a) = analytics {
+                            if let Ok(Some(label)) = &result {
+                                a.track(
+                                    analytics::Event::KeySwitched,
+                                    analytics::KeySwitchedPayload {
+                                        index,
+                                        label: label.clone(),
+                                    },
+                                );
+                            }
+                        }
+                        result.map(|_| ()).map_err(Into::into)
                     }
                     cli::KeysCommands::Delete { index } => {
-                        cli::commands::keys::delete_key(index, output_format, network)
-                            .await
-                            .map_err(Into::into)
+                        let result =
+                            cli::commands::keys::delete_key(index, output_format, network).await;
+                        if let Some(ref a) = analytics {
+                            if let Ok(Some(label)) = &result {
+                                a.track(
+                                    analytics::Event::KeyDeleted,
+                                    analytics::KeyDeletedPayload {
+                                        index,
+                                        label: label.clone(),
+                                    },
+                                );
+                            }
+                        }
+                        result.map(|_| ()).map_err(Into::into)
                     }
                 }
             } else {
+                if let Some(ref a) = analytics {
+                    a.track(analytics::Event::KeysListed, analytics::EmptyPayload);
+                }
                 cli::commands::keys::list_keys(output_format, network)
                     .await
                     .map_err(Into::into)
@@ -206,23 +325,65 @@ async fn handle_command(cli: Cli, command: Commands) -> Result<()> {
                 .await
                 .map_err(Into::into)
         }
+    };
+
+    if let Some(ref a) = analytics {
+        a.flush().await;
     }
+
+    result
 }
 
 /// Make an HTTP request (main flow)
-async fn make_request(cli: Cli, query: QueryArgs) -> Result<()> {
+async fn make_request(cli: Cli, query: QueryArgs, analytics: Option<Analytics>) -> Result<()> {
     let config = load_config_with_overrides(&cli)?;
 
     let url = query.url.clone();
     let request_ctx = RequestContext::new(cli, query)?;
+    let method_str = request_ctx.method.to_string();
+
+    if let Some(ref a) = analytics {
+        a.track(
+            analytics::Event::QueryStarted,
+            analytics::QueryStartedPayload {
+                url: url.clone(),
+                method: method_str.clone(),
+            },
+        );
+    }
 
     if request_ctx.cli.is_verbose() && request_ctx.cli.should_show_output() {
         eprintln!("Making {} request to: {url}", request_ctx.method);
     }
 
-    let response = request_ctx.execute(&url, None).await?;
+    let response = match request_ctx.execute(&url, None).await {
+        Ok(r) => r,
+        Err(e) => {
+            if let Some(ref a) = analytics {
+                a.track(
+                    analytics::Event::QueryFailure,
+                    analytics::QueryFailurePayload {
+                        url: url.clone(),
+                        method: method_str,
+                        error: e.to_string(),
+                    },
+                );
+            }
+            return Err(e);
+        }
+    };
 
     if !response.is_payment_required() {
+        if let Some(ref a) = analytics {
+            a.track(
+                analytics::Event::QuerySuccess,
+                analytics::QuerySuccessPayload {
+                    url: url.clone(),
+                    method: method_str,
+                    status_code: response.status_code,
+                },
+            );
+        }
         handle_regular_response(&request_ctx.cli, &request_ctx.query, response)?;
         return Ok(());
     }
@@ -242,11 +403,59 @@ async fn make_request(cli: Cli, query: QueryArgs) -> Result<()> {
         eprintln!("Payment protocol: {}", protocol);
     }
 
-    let response = handle_web_payment_request(&config, &request_ctx, &url, &response).await?;
+    if let Some(ref a) = analytics {
+        a.track(
+            analytics::Event::PaymentStarted,
+            analytics::PaymentStartedPayload {
+                network: String::new(),
+                amount: String::new(),
+                currency: String::new(),
+            },
+        );
+    }
 
-    handle_regular_response(&request_ctx.cli, &request_ctx.query, response)?;
-
-    Ok(())
+    match handle_web_payment_request(&config, &request_ctx, &url, &response).await {
+        Ok(response) => {
+            if let Some(ref a) = analytics {
+                a.track(
+                    analytics::Event::PaymentSuccess,
+                    analytics::PaymentSuccessPayload {
+                        network: String::new(),
+                        amount: String::new(),
+                        currency: String::new(),
+                        tx_hash: response
+                            .get_header("payment-receipt")
+                            .cloned()
+                            .unwrap_or_default(),
+                    },
+                );
+                a.track(
+                    analytics::Event::QuerySuccess,
+                    analytics::QuerySuccessPayload {
+                        url: url.clone(),
+                        method: method_str,
+                        status_code: response.status_code,
+                    },
+                );
+            }
+            handle_regular_response(&request_ctx.cli, &request_ctx.query, response)?;
+            Ok(())
+        }
+        Err(e) => {
+            if let Some(ref a) = analytics {
+                a.track(
+                    analytics::Event::PaymentFailure,
+                    analytics::PaymentFailurePayload {
+                        network: String::new(),
+                        amount: String::new(),
+                        currency: String::new(),
+                        error: e.to_string(),
+                    },
+                );
+            }
+            Err(e)
+        }
+    }
 }
 
 // ==================== Config Display ====================

--- a/src/wallet/manager.rs
+++ b/src/wallet/manager.rs
@@ -1,6 +1,6 @@
 //! Wallet manager for orchestrating browser-based authentication.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use alloy::primitives::Address;
 use alloy::rlp::Decodable;
@@ -8,6 +8,7 @@ use alloy::signers::local::PrivateKeySigner;
 use tempo_primitives::transaction::SignedKeyAuthorization;
 use url::Url;
 
+use crate::analytics::Analytics;
 use crate::error::{Result, TempoCtlError};
 use crate::wallet::auth_server::{run_callback_server, AuthCallback};
 use crate::wallet::credentials::{NetworkWallet, WalletCredentials};
@@ -19,11 +20,12 @@ const CALLBACK_TIMEOUT_SECS: u64 = 300; // 5 minutes
 pub struct WalletManager {
     auth_server_url: String,
     network: String,
+    analytics: Option<Analytics>,
 }
 
 impl WalletManager {
     /// Create a new wallet manager for a specific network.
-    pub fn new(network: Option<&str>) -> Self {
+    pub fn new(network: Option<&str>, analytics: Option<Analytics>) -> Self {
         let creds = WalletCredentials::load().unwrap_or_default();
         let network = network.unwrap_or(&creds.network).to_string();
 
@@ -34,6 +36,7 @@ impl WalletManager {
         Self {
             auth_server_url,
             network,
+            analytics,
         }
     }
 
@@ -89,7 +92,18 @@ impl WalletManager {
             println!("Please open this URL manually: {}", url_str);
         }
 
+        if let Some(ref a) = self.analytics {
+            a.track(
+                crate::analytics::Event::CallbackWindowOpened,
+                crate::analytics::CallbackWindowOpenedPayload {
+                    is_refresh: false,
+                    network: self.network.clone(),
+                },
+            );
+        }
+
         println!("\nWaiting for authentication...");
+        let wait_start = Instant::now();
 
         let callback = tokio::time::timeout(Duration::from_secs(CALLBACK_TIMEOUT_SECS), rx)
             .await
@@ -97,6 +111,16 @@ impl WalletManager {
             .map_err(|_| {
                 TempoCtlError::Http("Failed to receive authentication callback".to_string())
             })?;
+
+        if let Some(ref a) = self.analytics {
+            a.track(
+                crate::analytics::Event::CallbackReceived,
+                crate::analytics::CallbackReceivedPayload {
+                    network: self.network.clone(),
+                    duration_secs: wait_start.elapsed().as_secs(),
+                },
+            );
+        }
 
         self.save_credentials(callback, local_signer).await?;
 
@@ -134,7 +158,18 @@ impl WalletManager {
             println!("Please open this URL manually: {}", url_str);
         }
 
+        if let Some(ref a) = self.analytics {
+            a.track(
+                crate::analytics::Event::CallbackWindowOpened,
+                crate::analytics::CallbackWindowOpenedPayload {
+                    is_refresh: true,
+                    network: self.network.clone(),
+                },
+            );
+        }
+
         println!("\nWaiting for authentication...");
+        let wait_start = Instant::now();
 
         let callback = tokio::time::timeout(Duration::from_secs(CALLBACK_TIMEOUT_SECS), rx)
             .await
@@ -142,6 +177,16 @@ impl WalletManager {
             .map_err(|_| {
                 TempoCtlError::Http("Failed to receive authentication callback".to_string())
             })?;
+
+        if let Some(ref a) = self.analytics {
+            a.track(
+                crate::analytics::Event::CallbackReceived,
+                crate::analytics::CallbackReceivedPayload {
+                    network: self.network.clone(),
+                    duration_secs: wait_start.elapsed().as_secs(),
+                },
+            );
+        }
 
         self.save_access_key(callback, local_signer).await?;
 
@@ -183,6 +228,17 @@ impl WalletManager {
         creds.set_wallet(wallet);
         creds.save()?;
 
+        if let Some(ref a) = self.analytics {
+            a.track(
+                crate::analytics::Event::KeyCreated,
+                crate::analytics::KeyCreatedPayload {
+                    network: self.network.clone(),
+                    label: "Default".to_string(),
+                },
+            );
+            a.identify();
+        }
+
         Ok(())
     }
 
@@ -201,8 +257,8 @@ impl WalletManager {
         creds.network = self.network.clone();
 
         let private_key_hex = format!("0x{}", hex::encode(local_signer.to_bytes()));
-        let label = format!("Key {}", chrono_label());
-        let mut access_key = AccessKey::new(private_key_hex).with_label(label);
+        let key_label = format!("Key {}", chrono_label());
+        let mut access_key = AccessKey::new(private_key_hex).with_label(key_label.clone());
         let mut pending_hex = None;
 
         if let Some(v) = &validated {
@@ -225,6 +281,18 @@ impl WalletManager {
         }
 
         creds.save()?;
+
+        if let Some(ref a) = self.analytics {
+            a.track(
+                crate::analytics::Event::KeyCreated,
+                crate::analytics::KeyCreatedPayload {
+                    network: self.network.clone(),
+                    label: key_label,
+                },
+            );
+            a.identify();
+        }
+
         Ok(())
     }
 }
@@ -279,7 +347,7 @@ fn chrono_label() -> String {
 
 impl Default for WalletManager {
     fn default() -> Self {
-        Self::new(None)
+        Self::new(None, None)
     }
 }
 


### PR DESCRIPTION
- Add src/analytics/ module with PostHog integration
- Use official posthog-rs crate instead of hand-rolled HTTP
- Track events: login, query, payment, balance, keys, sessions
- Support identify/alias via $identify and $create_alias events
- Fire-and-forget via tokio::spawn, opt-out via TEMPOCTL_NO_TELEMETRY
- Use tempo_app_id property on all events

Co-authored-by: Amp <amp@ampcode.com>
Amp-Thread-ID: https://ampcode.com/threads/T-019c4800-453f-72ef-90c4-fea777052c93
