### PR TITLE
fix: install rust toolchain in changelog CI workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,6 +14,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Configure git for private repos
+        run: git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
       - name: Install changelogs
         run: curl -sSL https://changelogs.sh | sh
       - name: Generate changelog


### PR DESCRIPTION
The changelogs tool uses cargo_metadata internally to discover
workspace packages, which requires cargo to be installed.

Amp-Thread-ID: https://ampcode.com/threads/T-019c485d-f76c-73fe-8dc3-7d58ccd35f35
Co-authored-by: Amp <amp@ampcode.com>