### PR TITLE
fix(cd): revert R2 bucket name to pget-binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,11 +78,11 @@ jobs:
           AWS_ENDPOINT_URL: https://${{ secrets.CF_ACCOUNT_ID }}.r2.cloudflarestorage.com
         run: |
           for f in artifacts/*; do
-            aws s3 cp "$f" "s3://tempoctl-binaries/$(basename "$f")" --endpoint-url "$AWS_ENDPOINT_URL"
+            aws s3 cp "$f" "s3://pget-binaries/$(basename "$f")" --endpoint-url "$AWS_ENDPOINT_URL"
           done
 
           # Upload install script
-          aws s3 cp install.sh "s3://tempoctl-binaries/install.sh" --endpoint-url "$AWS_ENDPOINT_URL" --content-type "text/plain"
+          aws s3 cp install.sh "s3://pget-binaries/install.sh" --endpoint-url "$AWS_ENDPOINT_URL" --content-type "text/plain"
 
           echo "Uploaded latest binaries to R2"
 
@@ -126,7 +126,7 @@ jobs:
           # Upload with version prefix
           for f in artifacts/*; do
             BASENAME=$(basename "$f")
-            aws s3 cp "$f" "s3://tempoctl-binaries/${VERSION}/${BASENAME}" --endpoint-url "$AWS_ENDPOINT_URL"
+            aws s3 cp "$f" "s3://pget-binaries/${VERSION}/${BASENAME}" --endpoint-url "$AWS_ENDPOINT_URL"
           done
 
           echo "Uploaded ${VERSION} binaries to R2"


### PR DESCRIPTION
## Summary
Reverts the R2 bucket name from `tempoctl-binaries` back to `pget-binaries` in the release workflow.

## Motivation
PR #98 renamed the bucket, but the R2 API token (`R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY`) is scoped to the `pget-binaries` bucket. Every push to main since the rename (7 consecutive runs) fails with:

```
upload failed: artifacts/tempoctl-darwin-amd64 to s3://tempoctl-binaries/tempoctl-darwin-amd64
An error occurred (AccessDenied) when calling the CreateMultipartUpload operation: Access Denied
```

The public domain `tempoctl-binaries.tempo.xyz` in `ai-payments` can still route to the `pget-binaries` R2 bucket via Cloudflare custom domain config.

## Changes
- Reverted all 3 bucket references in `.github/workflows/release.yml` from `s3://tempoctl-binaries` to `s3://pget-binaries`

## Testing
N/A — workflow-only change. Merging this should unblock the next 7 failed uploads.

Thread: https://tempoxyz.slack.com/archives/C0A99L9RLHZ/p1770744376850819