### PR TITLE
fix: install claude CLI in changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,8 +17,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Configure git for private repos
         run: git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
-      - name: Install changelogs
-        run: curl -sSL https://changelogs.sh | sh
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install changelogs and claude CLI
+        run: |
+          curl -sSL https://changelogs.sh | sh
+          npm install -g @anthropic-ai/claude-code
       - name: Generate changelog
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
The changelogs tool spawns 'claude' as a subprocess for AI-generated
changelogs, which requires the Claude CLI to be installed.

Amp-Thread-ID: https://ampcode.com/threads/T-019c485d-f76c-73fe-8dc3-7d58ccd35f35
Co-authored-by: Amp <amp@ampcode.com>
