### PR TITLE
refactor: use tracing::warn instead of eprintln for warning logs

### DIFF
--- a/src/cli/commands/balance.rs
+++ b/src/cli/commands/balance.rs
@@ -6,6 +6,7 @@ use crate::payment::money::format_u256_with_decimals;
 use crate::payment::provider::{get_balances, NetworkBalance};
 use alloy::primitives::U256;
 use anyhow::Result;
+use tracing::warn;
 
 /// Check if mock mode is enabled for testing
 fn is_mock_mode() -> bool {
@@ -65,7 +66,7 @@ pub async fn balance_command(
         } else {
             match get_balances(config, &check_address, network).await {
                 Ok(network_balances) => balances.extend(network_balances),
-                Err(e) => eprintln!("Warning: Failed to get balances for {network}: {e}"),
+                Err(e) => warn!(network = %network, error = %e, "failed to get balances"),
             }
         }
     }

--- a/src/cli/commands/login.rs
+++ b/src/cli/commands/login.rs
@@ -3,6 +3,7 @@ use crate::config::Config;
 use crate::wallet::WalletManager;
 use anyhow::{Context, Result};
 use std::path::PathBuf;
+use tracing::warn;
 
 const TEMPOCTL_SKILL_CONTENT: &str = include_str!("../../../.ai/skills/tempoctl/SKILL.md");
 
@@ -23,7 +24,7 @@ pub async fn run_login(network: Option<&str>, analytics: Option<Analytics>) -> R
     match install_ai_integrations() {
         Ok(Some(path)) => println!("AI integrations installed to: {}", path.display()),
         Ok(None) => {}
-        Err(e) => eprintln!("Warning: Failed to install AI integrations: {e}"),
+        Err(e) => warn!(error = %e, "failed to install AI integrations"),
     }
 
     Ok(())

--- a/src/payment/provider.rs
+++ b/src/payment/provider.rs
@@ -19,7 +19,7 @@ use alloy::sol;
 use std::str::FromStr;
 use std::sync::Arc;
 use tempo_primitives::transaction::SignedKeyAuthorization;
-use tracing::debug;
+use tracing::{debug, warn};
 
 /// Balance information for a single token on a network
 #[derive(Debug, Clone)]
@@ -443,9 +443,11 @@ pub async fn get_balances(
                 ));
             }
             Err(e) => {
-                eprintln!(
-                    "Warning: Failed to get {} balance on {}: {}",
-                    token_config.currency.symbol, network, e
+                warn!(
+                    token = %token_config.currency.symbol,
+                    network = %network,
+                    error = %e,
+                    "failed to get token balance"
                 );
             }
         }
@@ -572,10 +574,7 @@ pub async fn find_swap_source(
                         }
                     }
                     Err(e) => {
-                        eprintln!(
-                            "Warning: Failed to query spending limit for {}: {}",
-                            symbol, e
-                        );
+                        warn!(token = %symbol, error = %e, "failed to query spending limit");
                         return None;
                     }
                 };
@@ -596,7 +595,7 @@ pub async fn find_swap_source(
                 }
                 Ok(_) => {}
                 Err(e) => {
-                    eprintln!("Warning: Failed to query {} balance: {}", symbol, e);
+                    warn!(token = %symbol, error = %e, "failed to query token balance");
                 }
             }
         }
@@ -621,7 +620,7 @@ pub async fn find_swap_source(
                 }
                 Ok(_) => {}
                 Err(e) => {
-                    eprintln!("Warning: Failed to query {} balance: {}", symbol, e);
+                    warn!(token = %symbol, error = %e, "failed to query token balance");
                 }
             }
         }


### PR DESCRIPTION
Replace eprintln! warning messages with tracing::warn! in the payment
provider for consistent structured logging.

Co-authored-by: Amp <amp@ampcode.com>
Amp-Thread-ID: https://ampcode.com/threads/T-019c4919-031f-7486-9a70-a48d6eaeda35
