### PR TITLE
feat: auto-prompt login on 402 in interactive terminals

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -340,7 +340,7 @@ async fn handle_command(cli: Cli, command: Commands) -> Result<()> {
 
 /// Make an HTTP request (main flow)
 async fn make_request(cli: Cli, query: QueryArgs, analytics: Option<Analytics>) -> Result<()> {
-    let config = load_config_with_overrides(&cli)?;
+    let mut config = load_config_with_overrides(&cli)?;
 
     let url = query.url.clone();
     let request_ctx = RequestContext::new(cli, query)?;
@@ -403,9 +403,18 @@ async fn make_request(cli: Cli, query: QueryArgs, analytics: Option<Analytics>) 
             .is_some();
 
     if !has_wallet && std::env::var("TEMPOCTL_MOCK_PAYMENT").is_err() {
-        anyhow::bail!(crate::error::TempoCtlError::ConfigMissing(
-            "This request requires payment, but no wallet is configured".to_string()
-        ));
+        use std::io::IsTerminal;
+        if std::io::stdin().is_terminal() {
+            eprintln!("This request requires payment. Let's connect your wallet first.\n");
+            let network = request_ctx.cli.network.as_deref();
+            cli::commands::login::run_login(network, analytics.clone()).await?;
+            eprintln!("\nRetrying request...");
+            config = load_config_with_overrides(&request_ctx.cli)?;
+        } else {
+            anyhow::bail!(crate::error::TempoCtlError::ConfigMissing(
+                "This request requires payment, but no wallet is configured".to_string()
+            ));
+        }
     }
 
     let protocol =

--- a/tests/payment_error_tests.rs
+++ b/tests/payment_error_tests.rs
@@ -135,6 +135,29 @@ impl Drop for TestServer {
 }
 
 #[test]
+fn test_no_wallet_non_interactive_errors() {
+    let server = TestServer::start_402_server();
+    let temp = setup_test_config();
+
+    let output = test_command(&temp)
+        .args(["query", &server.url("test")])
+        .output()
+        .expect("failed to run tempoctl");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no wallet is configured"),
+        "Expected 'no wallet is configured' error, got: {}",
+        stderr
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "Expected exit code 3 (ConfigError)"
+    );
+}
+
+#[test]
 fn test_spending_limit_exceeded_error() {
     let server = TestServer::start_402_server();
     let temp = setup_test_config();


### PR DESCRIPTION
## Summary
When a query hits a 402 and no wallet is configured, automatically prompt login if running interactively. Non-interactive contexts (piped, CI, agents) get the existing error.

## Changes
- `src/main.rs`: Check `stdin.is_terminal()` before bailing on missing wallet; run login flow and reload config if interactive
- `tests/payment_error_tests.rs`: Add `test_no_wallet_non_interactive_errors` covering the non-interactive path

## Follow-up
Add `--no-interactive` flag / `TEMPOCTL_NO_INTERACTIVE` env var for agents running in a real TTY.