### PR TITLE
feat: expand analytics events for funnel dashboards

### DIFF
--- a/src/analytics/events.rs
+++ b/src/analytics/events.rs
@@ -5,6 +5,7 @@ pub enum Event {
     LoginStarted,
     LoginSuccess,
     LoginFailure,
+    LoginTimeout,
     Logout,
 
     QueryStarted,
@@ -16,11 +17,17 @@ pub enum Event {
     PaymentFailure,
 
     BalanceChecked,
+
+    WalletRefreshStarted,
     WalletRefreshed,
+    WalletRefreshFailure,
 
     KeyCreated,
+    KeyListViewed,
     KeySwitched,
+    KeySwitchFailure,
     KeyDeleted,
+    KeyDeleteFailure,
     WhoamiViewed,
 
     CallbackWindowOpened,
@@ -36,6 +43,7 @@ impl Event {
             Self::LoginStarted => "login_started",
             Self::LoginSuccess => "login_success",
             Self::LoginFailure => "login_failure",
+            Self::LoginTimeout => "login_timeout",
             Self::Logout => "logout",
             Self::QueryStarted => "query_started",
             Self::QuerySuccess => "query_success",
@@ -44,10 +52,15 @@ impl Event {
             Self::PaymentSuccess => "payment_success",
             Self::PaymentFailure => "payment_failure",
             Self::BalanceChecked => "balance_checked",
+            Self::WalletRefreshStarted => "wallet_refresh_started",
             Self::WalletRefreshed => "wallet_refreshed",
+            Self::WalletRefreshFailure => "wallet_refresh_failure",
             Self::KeyCreated => "key_created",
+            Self::KeyListViewed => "key_list_viewed",
             Self::KeySwitched => "key_switched",
+            Self::KeySwitchFailure => "key_switch_failure",
             Self::KeyDeleted => "key_deleted",
+            Self::KeyDeleteFailure => "key_delete_failure",
             Self::WhoamiViewed => "whoami_viewed",
             Self::CallbackWindowOpened => "callback_window_opened",
             Self::CallbackReceived => "callback_received",
@@ -178,3 +191,23 @@ pub struct CallbackReceivedPayload {
     pub duration_secs: u64,
 }
 impl EventPayload for CallbackReceivedPayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LoginTimeoutPayload {
+    pub network: String,
+}
+impl EventPayload for LoginTimeoutPayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WalletRefreshFailurePayload {
+    pub network: String,
+    pub error: String,
+}
+impl EventPayload for WalletRefreshFailurePayload {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct KeyFailurePayload {
+    pub index: usize,
+    pub error: String,
+}
+impl EventPayload for KeyFailurePayload {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,29 +116,36 @@ async fn handle_command(cli: Cli, command: Commands) -> Result<()> {
                 a.track(
                     analytics::Event::LoginStarted,
                     analytics::LoginPayload {
-                        network: network.unwrap_or("tempo-moderato").to_string(),
+                        network: network.unwrap_or_default().to_string(),
                     },
                 );
             }
             let result = cli::commands::login::run_login(network, analytics.clone()).await;
             if let Some(ref a) = analytics {
+                let net = network.unwrap_or_default().to_string();
                 match &result {
                     Ok(()) => {
                         a.track(
                             analytics::Event::LoginSuccess,
-                            analytics::LoginPayload {
-                                network: network.unwrap_or("tempo-moderato").to_string(),
-                            },
+                            analytics::LoginPayload { network: net },
                         );
                     }
                     Err(e) => {
-                        a.track(
-                            analytics::Event::LoginFailure,
-                            analytics::LoginFailurePayload {
-                                network: network.unwrap_or("tempo-moderato").to_string(),
-                                error: e.to_string(),
-                            },
-                        );
+                        let err_str = e.to_string();
+                        if err_str.contains("timed out") {
+                            a.track(
+                                analytics::Event::LoginTimeout,
+                                analytics::LoginTimeoutPayload { network: net },
+                            );
+                        } else {
+                            a.track(
+                                analytics::Event::LoginFailure,
+                                analytics::LoginFailurePayload {
+                                    network: net,
+                                    error: err_str,
+                                },
+                            );
+                        }
                     }
                 }
             }
@@ -147,10 +154,13 @@ async fn handle_command(cli: Cli, command: Commands) -> Result<()> {
 
         Commands::Logout { yes } => {
             let network = cli.network.as_deref();
+            let result = cli::commands::logout::run_logout(yes, network).await;
             if let Some(ref a) = analytics {
-                a.track(analytics::Event::Logout, analytics::EmptyPayload);
+                if result.is_ok() {
+                    a.track(analytics::Event::Logout, analytics::EmptyPayload);
+                }
             }
-            cli::commands::logout::run_logout(yes, network).await
+            result
         }
 
         Commands::Completions { shell } => {
@@ -220,12 +230,31 @@ async fn handle_command(cli: Cli, command: Commands) -> Result<()> {
             let network = cli.network.as_deref();
             match command {
                 WalletCommands::Refresh => {
+                    if let Some(ref a) = analytics {
+                        a.track(
+                            analytics::Event::WalletRefreshStarted,
+                            analytics::LoginPayload {
+                                network: network.unwrap_or_default().to_string(),
+                            },
+                        );
+                    }
                     let result =
                         cli::commands::tempo_wallet::refresh_wallet(network, analytics.clone())
                             .await;
                     if let Some(ref a) = analytics {
-                        if result.is_ok() {
-                            a.track(analytics::Event::WalletRefreshed, analytics::EmptyPayload);
+                        match &result {
+                            Ok(()) => {
+                                a.track(analytics::Event::WalletRefreshed, analytics::EmptyPayload);
+                            }
+                            Err(e) => {
+                                a.track(
+                                    analytics::Event::WalletRefreshFailure,
+                                    analytics::WalletRefreshFailurePayload {
+                                        network: network.unwrap_or_default().to_string(),
+                                        error: e.to_string(),
+                                    },
+                                );
+                            }
                         }
                     }
                     result.map_err(Into::into)
@@ -276,6 +305,9 @@ async fn handle_command(cli: Cli, command: Commands) -> Result<()> {
             if let Some(subcommand) = command {
                 match subcommand {
                     cli::KeysCommands::List => {
+                        if let Some(ref a) = analytics {
+                            a.track(analytics::Event::KeyListViewed, analytics::EmptyPayload);
+                        }
                         cli::commands::keys::list_keys(output_format, network)
                             .await
                             .map_err(Into::into)
@@ -284,14 +316,26 @@ async fn handle_command(cli: Cli, command: Commands) -> Result<()> {
                         let result =
                             cli::commands::keys::switch_key(index, output_format, network).await;
                         if let Some(ref a) = analytics {
-                            if let Ok(Some(label)) = &result {
-                                a.track(
-                                    analytics::Event::KeySwitched,
-                                    analytics::KeySwitchedPayload {
-                                        index,
-                                        label: label.clone(),
-                                    },
-                                );
+                            match &result {
+                                Ok(Some(label)) => {
+                                    a.track(
+                                        analytics::Event::KeySwitched,
+                                        analytics::KeySwitchedPayload {
+                                            index,
+                                            label: label.clone(),
+                                        },
+                                    );
+                                }
+                                Err(e) => {
+                                    a.track(
+                                        analytics::Event::KeySwitchFailure,
+                                        analytics::KeyFailurePayload {
+                                            index,
+                                            error: e.to_string(),
+                                        },
+                                    );
+                                }
+                                _ => {}
                             }
                         }
                         result.map(|_| ()).map_err(Into::into)
@@ -300,20 +344,35 @@ async fn handle_command(cli: Cli, command: Commands) -> Result<()> {
                         let result =
                             cli::commands::keys::delete_key(index, output_format, network).await;
                         if let Some(ref a) = analytics {
-                            if let Ok(Some(label)) = &result {
-                                a.track(
-                                    analytics::Event::KeyDeleted,
-                                    analytics::KeyDeletedPayload {
-                                        index,
-                                        label: label.clone(),
-                                    },
-                                );
+                            match &result {
+                                Ok(Some(label)) => {
+                                    a.track(
+                                        analytics::Event::KeyDeleted,
+                                        analytics::KeyDeletedPayload {
+                                            index,
+                                            label: label.clone(),
+                                        },
+                                    );
+                                }
+                                Err(e) => {
+                                    a.track(
+                                        analytics::Event::KeyDeleteFailure,
+                                        analytics::KeyFailurePayload {
+                                            index,
+                                            error: e.to_string(),
+                                        },
+                                    );
+                                }
+                                _ => {}
                             }
                         }
                         result.map(|_| ()).map_err(Into::into)
                     }
                 }
             } else {
+                if let Some(ref a) = analytics {
+                    a.track(analytics::Event::KeyListViewed, analytics::EmptyPayload);
+                }
                 cli::commands::keys::list_keys(output_format, network)
                     .await
                     .map_err(Into::into)
@@ -433,13 +492,34 @@ async fn make_request(cli: Cli, query: QueryArgs, analytics: Option<Analytics>) 
         eprintln!("Payment protocol: {}", protocol);
     }
 
+    // Extract payment details from 402 response for analytics
+    let (pay_network, pay_amount, pay_currency) = response
+        .get_header("www-authenticate")
+        .and_then(|h| mpp::parse_www_authenticate(h).ok())
+        .map(|challenge| {
+            let network = payment::mpp_ext::method_to_network(&challenge.method)
+                .unwrap_or("")
+                .to_string();
+            let charge: Option<mpp::ChargeRequest> = challenge.request.decode().ok();
+            let amount = charge
+                .as_ref()
+                .map(|c| c.amount.clone())
+                .unwrap_or_default();
+            let currency = charge
+                .as_ref()
+                .map(|c| c.currency.clone())
+                .unwrap_or_default();
+            (network, amount, currency)
+        })
+        .unwrap_or_default();
+
     if let Some(ref a) = analytics {
         a.track(
             analytics::Event::PaymentStarted,
             analytics::PaymentStartedPayload {
-                network: String::new(),
-                amount: String::new(),
-                currency: String::new(),
+                network: pay_network.clone(),
+                amount: pay_amount.clone(),
+                currency: pay_currency.clone(),
             },
         );
     }
@@ -463,9 +543,9 @@ async fn make_request(cli: Cli, query: QueryArgs, analytics: Option<Analytics>) 
                     a.track(
                         analytics::Event::PaymentSuccess,
                         analytics::PaymentSuccessPayload {
-                            network: String::new(),
-                            amount: String::new(),
-                            currency: String::new(),
+                            network: pay_network,
+                            amount: pay_amount,
+                            currency: pay_currency,
                             tx_hash: String::new(),
                         },
                     );
@@ -491,9 +571,9 @@ async fn make_request(cli: Cli, query: QueryArgs, analytics: Option<Analytics>) 
                     a.track(
                         analytics::Event::PaymentFailure,
                         analytics::PaymentFailurePayload {
-                            network: String::new(),
-                            amount: String::new(),
-                            currency: String::new(),
+                            network: pay_network,
+                            amount: pay_amount,
+                            currency: pay_currency,
                             error: e.to_string(),
                         },
                     );
@@ -508,9 +588,9 @@ async fn make_request(cli: Cli, query: QueryArgs, analytics: Option<Analytics>) 
                     a.track(
                         analytics::Event::PaymentSuccess,
                         analytics::PaymentSuccessPayload {
-                            network: String::new(),
-                            amount: String::new(),
-                            currency: String::new(),
+                            network: pay_network,
+                            amount: pay_amount,
+                            currency: pay_currency,
                             tx_hash: response
                                 .get_header("payment-receipt")
                                 .cloned()
@@ -534,9 +614,9 @@ async fn make_request(cli: Cli, query: QueryArgs, analytics: Option<Analytics>) 
                     a.track(
                         analytics::Event::PaymentFailure,
                         analytics::PaymentFailurePayload {
-                            network: String::new(),
-                            amount: String::new(),
-                            currency: String::new(),
+                            network: pay_network,
+                            amount: pay_amount,
+                            currency: pay_currency,
                             error: e.to_string(),
                         },
                     );


### PR DESCRIPTION
Add missing events for sign-up, payment, access key, and wallet refresh
flows to enable PostHog funnel analysis:

- login_timeout: distinguish auth timeouts from other login failures
- wallet_refresh_started / wallet_refresh_failure: track refresh funnel
- key_list_viewed: track access key discovery
- key_switch_failure / key_delete_failure: track key management errors
- Populate payment_started/success/failure with actual network, amount,
  and currency parsed from the 402 WWW-Authenticate challenge
- Move logout event to fire only on successful disconnect
- Remove hardcoded "tempo-moderato" network defaults from analytics payloads

Amp-Thread-ID: https://ampcode.com/threads/T-019c68cb-8f20-779a-bcb0-bdf463f2b924
Co-authored-by: Amp <amp@ampcode.com>
