### PR TITLE
fix: resolve all clippy and ast-grep lint warnings

### DIFF
--- a/src/cli/commands/session.rs
+++ b/src/cli/commands/session.rs
@@ -17,6 +17,7 @@ pub fn list_sessions() -> Result<()> {
     println!("Active payment sessions:\n");
     for session in &sessions {
         let expired = if session.is_expired() {
+            // ast-grep-ignore: no-leading-whitespace-strings
             " (expired)"
         } else {
             ""

--- a/src/error.rs
+++ b/src/error.rs
@@ -424,8 +424,8 @@ mod tests {
 
     #[test]
     fn test_signing_with_context() {
-        use std::io::{Error as IoError, ErrorKind};
-        let source = IoError::new(ErrorKind::Other, "underlying error");
+        use std::io::Error as IoError;
+        let source = IoError::other("underlying error");
         let ctx = SigningContext {
             network: Some("tempo".to_string()),
             address: Some("0x123".to_string()),
@@ -462,8 +462,8 @@ mod tests {
 
     #[test]
     fn test_result_ext_with_signing_context() {
-        use std::io::{Error as IoError, ErrorKind};
-        let result: std::result::Result<(), IoError> = Err(IoError::new(ErrorKind::Other, "test"));
+        use std::io::Error as IoError;
+        let result: std::result::Result<(), IoError> = Err(IoError::other("test"));
         let ctx = SigningContext {
             network: Some("tempo".to_string()),
             address: None,
@@ -477,8 +477,8 @@ mod tests {
 
     #[test]
     fn test_result_ext_with_network() {
-        use std::io::{Error as IoError, ErrorKind};
-        let result: std::result::Result<(), IoError> = Err(IoError::new(ErrorKind::Other, "test"));
+        use std::io::Error as IoError;
+        let result: std::result::Result<(), IoError> = Err(IoError::other("test"));
         let presto_result = result.with_network("base-sepolia");
         assert!(presto_result.is_err());
         let err = presto_result.unwrap_err();
@@ -487,8 +487,8 @@ mod tests {
 
     #[test]
     fn test_with_network_on_signing_error() {
-        use std::io::{Error as IoError, ErrorKind};
-        let source = IoError::new(ErrorKind::Other, "test");
+        use std::io::Error as IoError;
+        let source = IoError::other("test");
         let err = PrestoError::signing_with_context(source, SigningContext::default());
         let err_with_network = err.with_network("optimism");
         assert!(err_with_network.to_string().contains("optimism"));

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -342,6 +342,7 @@ mod tests {
     fn test_token_config_by_address() {
         let config = Network::Tempo
             .token_config_by_address(tempo_tokens::PATH_USD)
+            // ast-grep-ignore: no-unwrap-in-lib
             .unwrap();
         assert_eq!(config.currency.symbol, "pathUSD");
     }

--- a/src/payment/abi.rs
+++ b/src/payment/abi.rs
@@ -87,6 +87,7 @@ mod tests {
     fn test_transfer_encoding() {
         let recipient: Address = "0x496bc2392ba3b6179a15435ed09dad18d85a1705"
             .parse()
+            // ast-grep-ignore: no-unwrap-in-lib
             .unwrap();
         let amount = U256::from(1000u64);
 
@@ -99,6 +100,7 @@ mod tests {
     fn test_transfer_with_memo_encoding() {
         let recipient: Address = "0x496bc2392ba3b6179a15435ed09dad18d85a1705"
             .parse()
+            // ast-grep-ignore: no-unwrap-in-lib
             .unwrap();
         let amount = U256::from(1000u64);
         let memo: [u8; 32] = [
@@ -128,9 +130,11 @@ mod tests {
     fn test_swap_exact_amount_out_encoding() {
         let token_in: Address = "0x20c0000000000000000000000000000000000001"
             .parse()
+            // ast-grep-ignore: no-unwrap-in-lib
             .unwrap();
         let token_out: Address = "0x20c0000000000000000000000000000000000000"
             .parse()
+            // ast-grep-ignore: no-unwrap-in-lib
             .unwrap();
         let amount_out: u128 = 1_000_000;
         let max_amount_in: u128 = 1_005_000; // 0.5% slippage

--- a/src/payment/mpp_ext.rs
+++ b/src/payment/mpp_ext.rs
@@ -105,6 +105,24 @@ impl ChargeRequestExt for ChargeRequest {
     }
 }
 
+/// Extract the `txHash` field from a base64url-encoded receipt, if present.
+///
+/// The mpp `Receipt` struct only captures `reference` (which for session
+/// receipts is the channel ID). The server also includes a `txHash` field
+/// with the actual on-chain transaction hash. This function decodes the
+/// raw receipt to extract it.
+pub(crate) fn extract_tx_hash(receipt_b64: &str) -> Option<String> {
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+
+    let decoded = URL_SAFE_NO_PAD.decode(receipt_b64.trim()).ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
+    json.get("txHash")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -138,6 +156,7 @@ mod tests {
             realm: "test.example.com".to_string(),
             method: MethodName::new("tempo"),
             intent: "charge".into(),
+            // ast-grep-ignore: no-unwrap-in-lib
             request: Base64UrlJson::from_value(&serde_json::json!({})).unwrap(),
             digest: None,
             description: None,
@@ -154,6 +173,7 @@ mod tests {
             realm: "test.example.com".to_string(),
             method: MethodName::new("bitcoin"),
             intent: "charge".into(),
+            // ast-grep-ignore: no-unwrap-in-lib
             request: Base64UrlJson::from_value(&serde_json::json!({})).unwrap(),
             digest: None,
             description: None,
@@ -170,6 +190,7 @@ mod tests {
             realm: "test.example.com".to_string(),
             method: MethodName::new("tempo"),
             intent: "session".into(),
+            // ast-grep-ignore: no-unwrap-in-lib
             request: Base64UrlJson::from_value(&serde_json::json!({})).unwrap(),
             digest: None,
             description: None,
@@ -186,6 +207,7 @@ mod tests {
             realm: "test.example.com".to_string(),
             method: MethodName::new("tempo"),
             intent: "charge".into(),
+            // ast-grep-ignore: no-unwrap-in-lib
             request: Base64UrlJson::from_value(&serde_json::json!({})).unwrap(),
             digest: None,
             description: None,
@@ -215,22 +237,4 @@ mod tests {
         };
         assert!(req.money(Network::TempoModerato).is_err());
     }
-}
-
-/// Extract the `txHash` field from a base64url-encoded receipt, if present.
-///
-/// The mpp `Receipt` struct only captures `reference` (which for session
-/// receipts is the channel ID). The server also includes a `txHash` field
-/// with the actual on-chain transaction hash. This function decodes the
-/// raw receipt to extract it.
-pub(crate) fn extract_tx_hash(receipt_b64: &str) -> Option<String> {
-    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-    use base64::Engine;
-
-    let decoded = URL_SAFE_NO_PAD.decode(receipt_b64.trim()).ok()?;
-    let json: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
-    json.get("txHash")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
 }

--- a/src/payment/provider.rs
+++ b/src/payment/provider.rs
@@ -216,7 +216,11 @@ impl PrestoPaymentProvider {
                 {
                     Ok(limit) => limit,
                     Err(_) if pending_auth.is_some() => {
-                        pending_key_spending_limit(pending_auth.as_ref().unwrap(), required_token)
+                        // ast-grep-ignore: no-unwrap-in-lib
+                        pending_key_spending_limit(
+                            pending_auth.as_ref().expect("checked is_some"),
+                            required_token,
+                        )
                     }
                     Err(e) => {
                         return Err(mpp::MppError::Http(format!(
@@ -571,7 +575,11 @@ pub async fn find_swap_source(
                     Ok(Some(l)) if l >= amount_with_slippage => l,
                     Ok(Some(_)) => return None,
                     Err(_) if pending_auth.is_some() => {
-                        match pending_key_spending_limit(pending_auth.unwrap(), token_address) {
+                        // ast-grep-ignore: no-unwrap-in-lib
+                        match pending_key_spending_limit(
+                            pending_auth.expect("checked is_some"),
+                            token_address,
+                        ) {
                             None => U256::MAX,
                             Some(l) if l >= amount_with_slippage => l,
                             Some(_) => return None,

--- a/src/payment/providers/tempo.rs
+++ b/src/payment/providers/tempo.rs
@@ -747,6 +747,7 @@ fn create_tempo_transaction_with_calls(
 mod tests {
     use super::*;
 
+    #[allow(clippy::too_many_arguments)]
     fn create_tempo_transaction(
         signer: &PrivateKeySigner,
         chain_id: u64,
@@ -795,6 +796,7 @@ mod tests {
         let signer: PrivateKeySigner =
             "0x1234567890123456789012345678901234567890123456789012345678901234"
                 .parse()
+                // ast-grep-ignore: no-unwrap-in-lib
                 .unwrap();
 
         let asset = Address::ZERO;
@@ -812,6 +814,7 @@ mod tests {
         );
 
         assert!(result.is_ok());
+        // ast-grep-ignore: no-unwrap-in-lib
         let tx_hex = result.unwrap();
         assert!(tx_hex.starts_with("76"));
     }
@@ -821,6 +824,7 @@ mod tests {
         let signer: PrivateKeySigner =
             "0x1234567890123456789012345678901234567890123456789012345678901234"
                 .parse()
+                // ast-grep-ignore: no-unwrap-in-lib
                 .unwrap();
 
         let asset = Address::ZERO;
@@ -839,6 +843,7 @@ mod tests {
         );
 
         assert!(result.is_ok());
+        // ast-grep-ignore: no-unwrap-in-lib
         let tx_hex = result.unwrap();
         assert!(tx_hex.starts_with("76"));
     }
@@ -848,6 +853,7 @@ mod tests {
         let signer: PrivateKeySigner =
             "0x1234567890123456789012345678901234567890123456789012345678901234"
                 .parse()
+                // ast-grep-ignore: no-unwrap-in-lib
                 .unwrap();
 
         let asset = Address::ZERO;
@@ -864,6 +870,7 @@ mod tests {
             None,
             None,
         )
+        // ast-grep-ignore: no-unwrap-in-lib
         .unwrap();
 
         let keychain_tx = create_tempo_transaction(
@@ -876,6 +883,7 @@ mod tests {
             Some(wallet_address),
             None,
         )
+        // ast-grep-ignore: no-unwrap-in-lib
         .unwrap();
 
         assert!(keychain_tx.len() > direct_tx.len());
@@ -885,9 +893,11 @@ mod tests {
     fn test_swap_info_slippage_calculation() {
         let token_in: Address = "0x20c0000000000000000000000000000000000001"
             .parse()
+            // ast-grep-ignore: no-unwrap-in-lib
             .unwrap();
         let token_out: Address = "0x20c0000000000000000000000000000000000000"
             .parse()
+            // ast-grep-ignore: no-unwrap-in-lib
             .unwrap();
         let amount_out = U256::from(1_000_000u64); // 1 USDC
 
@@ -918,9 +928,11 @@ mod tests {
     fn test_swap_info_preserves_addresses() {
         let token_in: Address = "0x20c0000000000000000000000000000000000001"
             .parse()
+            // ast-grep-ignore: no-unwrap-in-lib
             .unwrap();
         let token_out: Address = "0x20c0000000000000000000000000000000000000"
             .parse()
+            // ast-grep-ignore: no-unwrap-in-lib
             .unwrap();
         let amount_out = U256::from(100u64);
 
@@ -942,28 +954,35 @@ mod tests {
 
         let token_in: Address = "0x20c0000000000000000000000000000000000001"
             .parse()
+            // ast-grep-ignore: no-unwrap-in-lib
             .unwrap();
         let token_out: Address = "0x20c0000000000000000000000000000000000000"
             .parse()
+            // ast-grep-ignore: no-unwrap-in-lib
             .unwrap();
         let recipient: Address = "0x1234567890123456789012345678901234567890"
             .parse()
+            // ast-grep-ignore: no-unwrap-in-lib
             .unwrap();
         let amount = U256::from(1_000_000u64);
 
         let swap_info = SwapInfo::new(token_in, token_out, amount);
+        // ast-grep-ignore: no-unwrap-in-lib
         let calls = build_swap_calls(&swap_info, recipient, amount, None).unwrap();
 
         // Should produce exactly 3 calls
         assert_eq!(calls.len(), 3);
 
         // Call 1: approve on token_in
+        // ast-grep-ignore: no-unwrap-in-lib
         assert_eq!(calls[0].to.to().unwrap(), &token_in);
 
         // Call 2: swap on DEX
+        // ast-grep-ignore: no-unwrap-in-lib
         assert_eq!(calls[1].to.to().unwrap(), &DEX_ADDRESS);
 
         // Call 3: transfer on token_out
+        // ast-grep-ignore: no-unwrap-in-lib
         assert_eq!(calls[2].to.to().unwrap(), &token_out);
 
         // All calls should have zero value
@@ -979,6 +998,7 @@ mod tests {
         let memo = Some([0xab; 32]);
 
         let swap_info = SwapInfo::new(token_in, token_out, amount);
+        // ast-grep-ignore: no-unwrap-in-lib
         let calls = build_swap_calls(&swap_info, recipient, amount, memo).unwrap();
 
         // Should still produce 3 calls with memo
@@ -1000,6 +1020,7 @@ mod tests {
         let signer: PrivateKeySigner =
             "0x1234567890123456789012345678901234567890123456789012345678901234"
                 .parse()
+                // ast-grep-ignore: no-unwrap-in-lib
                 .unwrap();
 
         let asset = Address::ZERO;
@@ -1014,6 +1035,7 @@ mod tests {
             limits: None,
         };
 
+        // ast-grep-ignore: no-unwrap-in-lib
         let inner_sig = signer.sign_hash_sync(&key_auth.signature_hash()).unwrap();
         let signed_auth = key_auth.into_signed(PrimitiveSignature::Secp256k1(inner_sig));
 
@@ -1027,6 +1049,7 @@ mod tests {
             Some(wallet_address),
             None,
         )
+        // ast-grep-ignore: no-unwrap-in-lib
         .unwrap();
 
         let tx_with = create_tempo_transaction(
@@ -1039,6 +1062,7 @@ mod tests {
             Some(wallet_address),
             Some(signed_auth),
         )
+        // ast-grep-ignore: no-unwrap-in-lib
         .unwrap();
 
         assert!(tx_with.len() > tx_without.len());
@@ -1050,6 +1074,7 @@ mod tests {
         let signer: PrivateKeySigner =
             "0x1234567890123456789012345678901234567890123456789012345678901234"
                 .parse()
+                // ast-grep-ignore: no-unwrap-in-lib
                 .unwrap();
 
         let asset = Address::ZERO;
@@ -1067,6 +1092,7 @@ mod tests {
         );
 
         assert!(result.is_ok());
+        // ast-grep-ignore: no-unwrap-in-lib
         let tx_hex = result.unwrap();
         assert!(tx_hex.starts_with("76"));
     }
@@ -1078,6 +1104,7 @@ mod tests {
         let signer: PrivateKeySigner =
             "0x1234567890123456789012345678901234567890123456789012345678901234"
                 .parse()
+                // ast-grep-ignore: no-unwrap-in-lib
                 .unwrap();
 
         let auth = KeyAuthorization {
@@ -1088,6 +1115,7 @@ mod tests {
             limits: None,
         };
 
+        // ast-grep-ignore: no-unwrap-in-lib
         let inner_sig = signer.sign_hash_sync(&auth.signature_hash()).unwrap();
         let signed = auth.into_signed(PrimitiveSignature::Secp256k1(inner_sig));
 
@@ -1102,6 +1130,7 @@ mod tests {
         let signer: PrivateKeySigner =
             "0x1234567890123456789012345678901234567890123456789012345678901234"
                 .parse()
+                // ast-grep-ignore: no-unwrap-in-lib
                 .unwrap();
 
         let token = Address::repeat_byte(0x01);
@@ -1115,6 +1144,7 @@ mod tests {
             limits: Some(vec![TokenLimit { token, limit }]),
         };
 
+        // ast-grep-ignore: no-unwrap-in-lib
         let inner_sig = signer.sign_hash_sync(&auth.signature_hash()).unwrap();
         let signed = auth.into_signed(PrimitiveSignature::Secp256k1(inner_sig));
 
@@ -1128,6 +1158,7 @@ mod tests {
         let signer: PrivateKeySigner =
             "0x1234567890123456789012345678901234567890123456789012345678901234"
                 .parse()
+                // ast-grep-ignore: no-unwrap-in-lib
                 .unwrap();
 
         let allowed_token = Address::repeat_byte(0x01);
@@ -1144,6 +1175,7 @@ mod tests {
             }]),
         };
 
+        // ast-grep-ignore: no-unwrap-in-lib
         let inner_sig = signer.sign_hash_sync(&auth.signature_hash()).unwrap();
         let signed = auth.into_signed(PrimitiveSignature::Secp256k1(inner_sig));
 
@@ -1160,6 +1192,7 @@ mod tests {
         let signer: PrivateKeySigner =
             "0x1234567890123456789012345678901234567890123456789012345678901234"
                 .parse()
+                // ast-grep-ignore: no-unwrap-in-lib
                 .unwrap();
 
         let auth = KeyAuthorization {
@@ -1170,6 +1203,7 @@ mod tests {
             limits: Some(vec![]),
         };
 
+        // ast-grep-ignore: no-unwrap-in-lib
         let inner_sig = signer.sign_hash_sync(&auth.signature_hash()).unwrap();
         let signed = auth.into_signed(PrimitiveSignature::Secp256k1(inner_sig));
 
@@ -1194,6 +1228,7 @@ mod tests {
             input: alloy::primitives::Bytes::from_static(&[0xaa, 0xbb]),
         }];
 
+        // ast-grep-ignore: no-unwrap-in-lib
         let req = build_estimate_gas_request(from, chain_id, nonce, fee_token, &calls, &gas, None)
             .unwrap();
 
@@ -1208,6 +1243,7 @@ mod tests {
         assert_eq!(req["feeToken"], format!("{:#x}", fee_token));
         assert_eq!(req["nonceKey"], "0x0");
 
+        // ast-grep-ignore: no-unwrap-in-lib
         let calls_json = req["calls"].as_array().unwrap();
         assert_eq!(calls_json.len(), 1);
         assert_eq!(calls_json[0]["to"], format!("{:#x}", call_to));
@@ -1240,6 +1276,7 @@ mod tests {
             },
         ];
 
+        // ast-grep-ignore: no-unwrap-in-lib
         let req = build_estimate_gas_request(
             from,
             4217,
@@ -1251,6 +1288,7 @@ mod tests {
         )
         .unwrap();
 
+        // ast-grep-ignore: no-unwrap-in-lib
         let calls_json = req["calls"].as_array().unwrap();
         assert_eq!(calls_json.len(), 3);
         assert_eq!(calls_json[1]["value"], format!("{:#x}", 42u64));
@@ -1265,6 +1303,7 @@ mod tests {
         let signer: PrivateKeySigner =
             "0x1234567890123456789012345678901234567890123456789012345678901234"
                 .parse()
+                // ast-grep-ignore: no-unwrap-in-lib
                 .unwrap();
 
         let auth = KeyAuthorization {
@@ -1274,6 +1313,7 @@ mod tests {
             expiry: Some(9999999999),
             limits: None,
         };
+        // ast-grep-ignore: no-unwrap-in-lib
         let inner_sig = signer.sign_hash_sync(&auth.signature_hash()).unwrap();
         let signed_auth = auth.into_signed(PrimitiveSignature::Secp256k1(inner_sig));
 
@@ -1283,6 +1323,7 @@ mod tests {
             input: alloy::primitives::Bytes::new(),
         }];
 
+        // ast-grep-ignore: no-unwrap-in-lib
         let req = build_estimate_gas_request(
             Address::ZERO,
             42431,
@@ -1302,12 +1343,14 @@ mod tests {
     #[test]
     fn test_parse_gas_estimate_with_buffer_hex_prefix() {
         // 100_000 = 0x186a0 → with +5000 buffer = 105_000
+        // ast-grep-ignore: no-unwrap-in-lib
         let result = parse_gas_estimate_with_buffer("0x186a0").unwrap();
         assert_eq!(result, 105_000);
     }
 
     #[test]
     fn test_parse_gas_estimate_with_buffer_no_prefix() {
+        // ast-grep-ignore: no-unwrap-in-lib
         let result = parse_gas_estimate_with_buffer("186a0").unwrap();
         assert_eq!(result, 105_000);
     }
@@ -1315,12 +1358,15 @@ mod tests {
     #[test]
     fn test_parse_gas_estimate_with_buffer_fixed() {
         // 1 gas → 1 + 5000 = 5001
+        // ast-grep-ignore: no-unwrap-in-lib
         assert_eq!(parse_gas_estimate_with_buffer("0x1").unwrap(), 5_001);
 
         // 5 gas → 5 + 5000 = 5005
+        // ast-grep-ignore: no-unwrap-in-lib
         assert_eq!(parse_gas_estimate_with_buffer("0x5").unwrap(), 5_005);
 
         // 250_000 gas → 250000 + 5000 = 255_000
+        // ast-grep-ignore: no-unwrap-in-lib
         assert_eq!(parse_gas_estimate_with_buffer("0x3d090").unwrap(), 255_000);
     }
 
@@ -1338,7 +1384,9 @@ mod tests {
 
     fn decode_gas_limit(tx_hex: &str) -> u64 {
         use alloy::eips::eip2718::Decodable2718;
+        // ast-grep-ignore: no-unwrap-in-lib
         let bytes = hex::decode(tx_hex).unwrap();
+        // ast-grep-ignore: no-unwrap-in-lib
         let signed = AASigned::decode_2718(&mut bytes.as_slice()).unwrap();
         signed.tx().gas_limit
     }
@@ -1348,6 +1396,7 @@ mod tests {
         let signer: PrivateKeySigner =
             "0x1234567890123456789012345678901234567890123456789012345678901234"
                 .parse()
+                // ast-grep-ignore: no-unwrap-in-lib
                 .unwrap();
 
         let asset = Address::ZERO;
@@ -1364,10 +1413,12 @@ mod tests {
             None,
             None,
         )
+        // ast-grep-ignore: no-unwrap-in-lib
         .unwrap();
 
         let tx_nonce_1 =
             create_tempo_transaction(&signer, 42431, 1, asset, transfer_data, &gas, None, None)
+                // ast-grep-ignore: no-unwrap-in-lib
                 .unwrap();
 
         assert_eq!(

--- a/src/payment/session_store.rs
+++ b/src/payment/session_store.rs
@@ -203,6 +203,7 @@ mod tests {
     fn test_is_expired_future() {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
+            // ast-grep-ignore: no-unwrap-in-lib
             .unwrap()
             .as_secs();
         let record = SessionRecord {

--- a/src/payment/web_payment.rs
+++ b/src/payment/web_payment.rs
@@ -283,6 +283,7 @@ fn classify_payment_provider_error(err: mpp::MppError) -> crate::error::PrestoEr
     }
 
     if msg_lower.contains("insufficient") && msg_lower.contains("balance") {
+        // ast-grep-ignore: no-leading-whitespace-strings
         let token = extract_between(&msg, "Insufficient ", " balance");
         let available = extract_field(&msg, "have")
             .and_then(|s| s.split_whitespace().next().map(|v| v.to_string()));
@@ -396,6 +397,7 @@ mod tests {
     #[test]
     fn test_validate_constraints_no_constraints() {
         let query = default_query();
+        // ast-grep-ignore: no-unwrap-in-lib
         let cli = Cli::try_parse_from(["presto"]).unwrap();
         let (challenge, charge_req) = mock_challenge(MethodName::new("tempo"), "1000000");
 
@@ -406,6 +408,7 @@ mod tests {
     #[test]
     fn test_validate_constraints_max_amount_ok() {
         let query = make_query_args(&["query", "--max-amount", "2000000", "http://example.com"]);
+        // ast-grep-ignore: no-unwrap-in-lib
         let cli = Cli::try_parse_from(["presto"]).unwrap();
         let (challenge, charge_req) = mock_challenge(MethodName::new("tempo"), "1000000");
 
@@ -416,6 +419,7 @@ mod tests {
     #[test]
     fn test_validate_constraints_max_amount_exceeded() {
         let query = make_query_args(&["query", "--max-amount", "500000", "http://example.com"]);
+        // ast-grep-ignore: no-unwrap-in-lib
         let cli = Cli::try_parse_from(["presto"]).unwrap();
         let (challenge, charge_req) = mock_challenge(MethodName::new("tempo"), "1000000");
 
@@ -432,6 +436,7 @@ mod tests {
     #[test]
     fn test_validate_constraints_max_amount_equal() {
         let query = make_query_args(&["query", "--max-amount", "1000000", "http://example.com"]);
+        // ast-grep-ignore: no-unwrap-in-lib
         let cli = Cli::try_parse_from(["presto"]).unwrap();
         let (challenge, charge_req) = mock_challenge(MethodName::new("tempo"), "1000000");
 
@@ -442,6 +447,7 @@ mod tests {
     #[test]
     fn test_validate_constraints_network_filter_match() {
         let query = default_query();
+        // ast-grep-ignore: no-unwrap-in-lib
         let cli = Cli::try_parse_from(["presto", "--network", "tempo-moderato"]).unwrap();
         let (challenge, charge_req) = mock_challenge(MethodName::new("tempo"), "1000000");
 
@@ -452,6 +458,7 @@ mod tests {
     #[test]
     fn test_validate_constraints_network_filter_no_match() {
         let query = default_query();
+        // ast-grep-ignore: no-unwrap-in-lib
         let cli = Cli::try_parse_from(["presto", "--network", "ethereum"]).unwrap();
         let (challenge, charge_req) = mock_challenge(MethodName::new("tempo"), "1000000");
 
@@ -468,6 +475,7 @@ mod tests {
     #[test]
     fn test_validate_constraints_multiple_networks() {
         let query = default_query();
+        // ast-grep-ignore: no-unwrap-in-lib
         let cli = Cli::try_parse_from(["presto", "--network", "tempo-moderato, ethereum"]).unwrap();
         let (challenge, charge_req) = mock_challenge(MethodName::new("tempo"), "1000000");
 
@@ -478,6 +486,7 @@ mod tests {
     #[test]
     fn test_validate_constraints_tempo_network() {
         let query = default_query();
+        // ast-grep-ignore: no-unwrap-in-lib
         let cli = Cli::try_parse_from(["presto", "--network", "tempo-moderato"]).unwrap();
         let (challenge, charge_req) = mock_challenge(MethodName::new("tempo"), "1000000");
 
@@ -488,6 +497,7 @@ mod tests {
     #[test]
     fn test_validate_constraints_combined() {
         let query = make_query_args(&["query", "--max-amount", "2000000", "http://example.com"]);
+        // ast-grep-ignore: no-unwrap-in-lib
         let cli = Cli::try_parse_from(["presto", "--network", "tempo-moderato"]).unwrap();
         let (challenge, charge_req) = mock_challenge(MethodName::new("tempo"), "1000000");
 
@@ -514,6 +524,7 @@ mod tests {
     fn test_extract_between_token() {
         let msg = "Insufficient pathUSD balance: have 0.50, need 1.00";
         assert_eq!(
+            // ast-grep-ignore: no-leading-whitespace-strings
             extract_between(msg, "Insufficient ", " balance"),
             Some("pathUSD".into())
         );
@@ -523,6 +534,7 @@ mod tests {
     fn test_extract_between_address_token() {
         let msg = "Insufficient 0x20c0000000000000000000000000000000000000 balance: have 0, need 1";
         assert_eq!(
+            // ast-grep-ignore: no-leading-whitespace-strings
             extract_between(msg, "Insufficient ", " balance"),
             Some("0x20c0000000000000000000000000000000000000".into())
         );
@@ -531,6 +543,7 @@ mod tests {
     #[test]
     fn test_extract_between_no_match() {
         assert_eq!(
+            // ast-grep-ignore: no-leading-whitespace-strings
             extract_between("no match", "Insufficient ", " balance"),
             None
         );

--- a/src/payment/web_session.rs
+++ b/src/payment/web_session.rs
@@ -175,7 +175,8 @@ pub async fn handle_web_session_request(
         .is_some_and(|r| !r.is_expired() && r.payer == did);
 
     if reuse {
-        let record = existing.unwrap();
+        // `reuse` is only true when `existing.is_some()`
+        let record = existing.expect("checked is_some above");
         if request_ctx.cli.is_verbose() && request_ctx.cli.should_show_output() {
             eprintln!("Reusing existing session for {}", origin);
             eprintln!("  Channel: {}", record.channel_id);

--- a/src/wallet/access_key.rs
+++ b/src/wallet/access_key.rs
@@ -147,6 +147,7 @@ mod tests {
 
     #[test]
     fn test_access_key_address_without_0x_prefix() {
+        // ast-grep-ignore: no-unwrap-in-lib
         let key_hex = TEST_PRIVATE_KEY.strip_prefix("0x").unwrap();
         let key = AccessKey::new(key_hex.to_string());
         let address = key.address();
@@ -157,6 +158,7 @@ mod tests {
     fn test_access_key_is_expired() {
         let past_expiry = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
+            // ast-grep-ignore: no-unwrap-in-lib
             .unwrap()
             .as_secs()
             - 3600;
@@ -169,6 +171,7 @@ mod tests {
     fn test_access_key_not_expired() {
         let future_expiry = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
+            // ast-grep-ignore: no-unwrap-in-lib
             .unwrap()
             .as_secs()
             + 3600;
@@ -186,6 +189,7 @@ mod tests {
     #[test]
     fn test_access_key_signer() {
         let key = AccessKey::new(TEST_PRIVATE_KEY.to_string());
+        // ast-grep-ignore: no-unwrap-in-lib
         let signer = key.signer().unwrap();
         assert_eq!(
             format!("{:?}", signer.address()).to_lowercase(),

--- a/src/wallet/auth_server.rs
+++ b/src/wallet/auth_server.rs
@@ -219,6 +219,7 @@ mod tests {
 
     fn headers_with_origin(origin: &str) -> HeaderMap {
         let mut h = HeaderMap::new();
+        // ast-grep-ignore: no-unwrap-in-lib
         h.insert("origin", origin.parse().unwrap());
         h
     }
@@ -269,6 +270,7 @@ mod tests {
     #[test]
     fn test_rejects_referer_without_origin() {
         let mut h = HeaderMap::new();
+        // ast-grep-ignore: no-unwrap-in-lib
         h.insert("referer", "https://app.tempo.xyz/cli-auth".parse().unwrap());
         assert!(!is_origin_allowed(&h));
     }

--- a/src/wallet/credentials.rs
+++ b/src/wallet/credentials.rs
@@ -262,6 +262,7 @@ mod tests {
         };
         creds.tempo = Some(wallet);
 
+        // ast-grep-ignore: no-unwrap-in-lib
         let toml_str = toml::to_string_pretty(&creds).unwrap();
         assert!(toml_str.contains("network = \"tempo\""));
         assert!(toml_str.contains("account_address = \"0xtest\""));
@@ -281,6 +282,7 @@ mod tests {
         creds.tempo_moderato = Some(wallet);
 
         assert!(creds.active_wallet().is_some());
+        // ast-grep-ignore: no-unwrap-in-lib
         assert_eq!(creds.active_wallet().unwrap().account_address, "0xtest");
     }
 
@@ -322,11 +324,14 @@ mod tests {
         };
         creds.tempo = Some(wallet);
 
+        // ast-grep-ignore: no-unwrap-in-lib
         let toml_str = toml::to_string_pretty(&creds).unwrap();
         assert!(toml_str.contains("pending_key_authorization = \"abcdef1234\""));
 
+        // ast-grep-ignore: no-unwrap-in-lib
         let parsed: WalletCredentials = toml::from_str(&toml_str).unwrap();
         assert_eq!(
+            // ast-grep-ignore: no-unwrap-in-lib
             parsed.tempo.unwrap().pending_key_authorization,
             Some("abcdef1234".to_string())
         );
@@ -389,7 +394,9 @@ network = "tempo-moderato"
 account_address = "0xtest"
 active_key_index = 0
 "#;
+        // ast-grep-ignore: no-unwrap-in-lib
         let creds: WalletCredentials = toml::from_str(toml_str).unwrap();
+        // ast-grep-ignore: no-unwrap-in-lib
         let wallet = creds.tempo_moderato.unwrap();
         assert_eq!(wallet.account_address, "0xtest");
         assert!(wallet.pending_key_authorization.is_none());

--- a/src/wallet/manager.rs
+++ b/src/wallet/manager.rs
@@ -338,7 +338,7 @@ fn validate_key_authorization(
 fn chrono_label() -> String {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
+        .expect("system clock before UNIX epoch")
         .as_secs()
         .to_string()
 }
@@ -360,6 +360,7 @@ mod tests {
         let signer: PrivateKeySigner =
             "0x1234567890123456789012345678901234567890123456789012345678901234"
                 .parse()
+                // ast-grep-ignore: no-unwrap-in-lib
                 .unwrap();
 
         let auth = KeyAuthorization {
@@ -370,6 +371,7 @@ mod tests {
             limits: None,
         };
 
+        // ast-grep-ignore: no-unwrap-in-lib
         let sig = signer.sign_hash_sync(&auth.signature_hash()).unwrap();
         let signed = auth.into_signed(PrimitiveSignature::Secp256k1(sig));
 
@@ -384,6 +386,7 @@ mod tests {
         let hex = make_signed_auth_hex(signer.address());
         let result = validate_key_authorization(Some(&hex), signer.address());
         assert!(result.is_ok());
+        // ast-grep-ignore: no-unwrap-in-lib
         let validated = result.unwrap().unwrap();
         assert_eq!(validated.hex, hex);
         assert_eq!(validated.expiry, 9999999999);
@@ -404,6 +407,7 @@ mod tests {
     fn test_validate_key_authorization_none() {
         let result = validate_key_authorization(None, Address::ZERO);
         assert!(result.is_ok());
+        // ast-grep-ignore: no-unwrap-in-lib
         assert_eq!(result.unwrap(), None);
     }
 


### PR DESCRIPTION
- Replace IoError::new(ErrorKind::Other, ..) with IoError::other(..) (clippy::io_other_error)
- Move extract_tx_hash before #[cfg(test)] module (clippy::items_after_test_module)
- Allow clippy::too_many_arguments on test helper
- Replace .unwrap() with .expect() in library code (4 occurrences)
- Add ast-grep-ignore for .unwrap() in inline #[cfg(test)] modules (78 occurrences)
- Add ast-grep-ignore for intentional leading-whitespace strings (5 occurrences)

Amp-Thread-ID: https://ampcode.com/threads/T-019c68e8-9b6f-725d-aa7d-a36d49f0a04e
Co-authored-by: Amp <amp@ampcode.com>
