### PR TITLE
feat: validate --network flag against known networks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,8 +101,22 @@ fn parse_cli() -> Cli {
     }
 }
 
+/// Validate the --network flag value against known built-in networks.
+///
+/// This catches typos and invalid names early, before they cause silent
+/// failures in login/logout/whoami where the network name is used as an
+/// exact match to select wallet credentials.
+fn validate_network_flag(network: &str) -> Result<()> {
+    network::validate_network_name(network)
+        .map_err(|msg| anyhow::anyhow!(error::PrestoError::UnknownNetwork(msg)))
+}
+
 /// Handle CLI subcommands
 async fn handle_command(cli: Cli, command: Commands) -> Result<()> {
+    if let Some(ref network) = cli.network {
+        validate_network_flag(network)?;
+    }
+
     let analytics = Analytics::new(cli.network.as_deref()).await;
 
     if let Some(ref a) = analytics {

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -249,6 +249,23 @@ impl fmt::Display for Network {
 
 // ==================== Convenience Functions ====================
 
+/// Validate that a network name is a known built-in network.
+///
+/// Returns `Ok(())` if the name matches a built-in network,
+/// or an error with a suggestion message if not.
+pub fn validate_network_name(name: &str) -> std::result::Result<(), String> {
+    let all_names: Vec<&str> = Network::all().iter().map(|n| n.as_str()).collect();
+    if all_names.contains(&name) {
+        Ok(())
+    } else {
+        Err(format!(
+            "Unknown network '{}'. Available networks: {}",
+            name,
+            all_names.join(", ")
+        ))
+    }
+}
+
 /// Look up network info by name.
 #[must_use]
 pub fn get_network(name: &str) -> Option<NetworkInfo> {
@@ -378,5 +395,33 @@ mod tests {
         assert_eq!(Network::from_chain_id(42431), Some(Network::TempoModerato));
         assert_eq!(Network::from_chain_id(1337), Some(Network::TempoLocalnet));
         assert_eq!(Network::from_chain_id(99999), None);
+    }
+
+    #[test]
+    fn test_validate_network_name_valid() {
+        assert!(validate_network_name("tempo").is_ok());
+        assert!(validate_network_name("tempo-moderato").is_ok());
+        assert!(validate_network_name("tempo-localnet").is_ok());
+    }
+
+    #[test]
+    fn test_validate_network_name_invalid() {
+        let result = validate_network_name("not-a-network");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("Unknown network 'not-a-network'"));
+        assert!(err.contains("tempo"));
+        assert!(err.contains("tempo-moderato"));
+    }
+
+    #[test]
+    fn test_validate_network_name_empty() {
+        assert!(validate_network_name("").is_err());
+    }
+
+    #[test]
+    fn test_validate_network_name_case_sensitive() {
+        assert!(validate_network_name("Tempo").is_err());
+        assert!(validate_network_name("TEMPO").is_err());
     }
 }

--- a/tests/balance_command_tests.rs
+++ b/tests/balance_command_tests.rs
@@ -151,8 +151,8 @@ fn test_balance_invalid_network() {
             "invalid-network",
         ])
         .assert()
-        .success()
-        .stdout(predicate::str::contains("No balances found"));
+        .failure()
+        .stderr(predicate::str::contains("Unknown network"));
 }
 
 #[test]

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -9,7 +9,7 @@ use predicates::prelude::*;
 use std::process::Command;
 
 mod common;
-use common::{test_command, TestConfigBuilder};
+use common::{mock_test_command, test_command, TestConfigBuilder};
 
 #[test]
 fn test_login_mock_device_code() {
@@ -424,4 +424,73 @@ fn test_no_args_shows_help() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Usage"));
+}
+
+// ==================== Network Validation ====================
+
+#[test]
+fn test_invalid_network_flag_rejected() {
+    let temp = TestConfigBuilder::new().build();
+    let mut cmd = test_command(&temp);
+    cmd.args(["-n", "not-a-network", "balance"]);
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Unknown network"));
+}
+
+#[test]
+fn test_valid_network_flag_accepted() {
+    let temp = TestConfigBuilder::new().build();
+    let mut cmd = mock_test_command(&temp);
+    cmd.args([
+        "-n",
+        "tempo",
+        "balance",
+        "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+    ]);
+    cmd.assert().success();
+}
+
+#[test]
+fn test_valid_network_moderato_accepted() {
+    let temp = TestConfigBuilder::new().build();
+    let mut cmd = mock_test_command(&temp);
+    cmd.args([
+        "-n",
+        "tempo-moderato",
+        "balance",
+        "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+    ]);
+    cmd.assert().success();
+}
+
+#[test]
+fn test_invalid_network_env_var_rejected() {
+    let temp = TestConfigBuilder::new().build();
+    let mut cmd = test_command(&temp);
+    cmd.env("PRESTO_NETWORK", "bogus-chain");
+    cmd.arg("balance");
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Unknown network"));
+}
+
+#[test]
+fn test_invalid_network_whoami_rejected() {
+    let temp = TestConfigBuilder::new().build();
+    let mut cmd = test_command(&temp);
+    cmd.args(["-n", "foobar", "whoami"]);
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Unknown network"));
+}
+
+#[test]
+fn test_invalid_network_login_rejected() {
+    let temp = TestConfigBuilder::new().build();
+    let mut cmd = test_command(&temp);
+    cmd.args(["-n", "bad-net", "login"]);
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Unknown network"));
 }


### PR DESCRIPTION
## Summary

Validate the `--network` / `-n` flag (and `PRESTO_NETWORK` env var) against known built-in networks at the input boundary, before dispatching to subcommands.

## Motivation

Invalid network names caused silent failures across multiple commands:
- **login/logout/whoami**: the network string is used as an exact match to select wallet credentials — an unknown name would silently no-op (e.g., `set_wallet`/`clear_wallet` fall through the match with `_ => {}`)
- **balance**: `Network::by_name_filter()` would return an empty vec, showing "No balances found" with no indication the name was wrong

A typo like `--network tmepo` would produce confusing behavior with no error.

## Changes

- `src/network/types.rs`: added `validate_network_name()` that checks against built-in network names and returns an error listing available options
- `src/main.rs`: added `validate_network_flag()` called at the top of `handle_command()` — fails fast with `PrestoError::UnknownNetwork` before any subcommand runs
- `tests/balance_command_tests.rs`: updated `test_balance_invalid_network` to expect failure instead of silent success
- `tests/cli_tests.rs`: added 6 integration tests covering invalid network rejection (balance, whoami, login, env var) and valid network acceptance

## Testing

```
make check   # fmt, clippy, 371 tests, build — all green
```