### PR TITLE
feat: auto-open browser in non-interactive mode

### DIFF
--- a/src/wallet/manager.rs
+++ b/src/wallet/manager.rs
@@ -116,16 +116,21 @@ impl WalletManager {
         println!("Verification code: \x1b[1m{}\x1b[0m", display_code);
 
         if !is_mock {
-            print!(
-                "\x1b[1mPress Enter\x1b[0m to open your browser to {}... ",
-                url_str
-            );
-            std::io::Write::flush(&mut std::io::stdout()).ok();
-            tokio::task::spawn_blocking(|| {
-                let _ = std::io::stdin().read_line(&mut String::new());
-            })
-            .await
-            .ok();
+            use std::io::IsTerminal;
+            if std::io::stdin().is_terminal() {
+                print!(
+                    "\x1b[1mPress Enter\x1b[0m to open your browser to {}... ",
+                    url_str
+                );
+                std::io::Write::flush(&mut std::io::stdout()).ok();
+                tokio::task::spawn_blocking(|| {
+                    let _ = std::io::stdin().read_line(&mut String::new());
+                })
+                .await
+                .ok();
+            } else {
+                println!("Opening browser to {}...", url_str);
+            }
 
             if let Err(e) = webbrowser::open(&url_str) {
                 eprintln!("Failed to open browser: {}", e);


### PR DESCRIPTION
## Summary
Auto-open the browser during login when stdin is not a TTY, instead of blocking on "Press Enter".

## Motivation
When presto is invoked from scripts or agents (non-interactive), the `read_line` on stdin returns immediately (EOF) but the UX is confusing — it still prints "Press Enter". Better to detect non-interactive mode and skip the prompt entirely.

## Changes
- `src/wallet/manager.rs`: Check `stdin().is_terminal()` before prompting. In non-interactive mode, print a message and open the browser immediately.

## Testing
`make check` — all 361 tests pass, clippy and fmt clean.