### PR TITLE
fix: remove redundant 'presto login' hint from ConfigMissing messages

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -296,7 +296,7 @@ async fn ensure_wallet_or_prompt_login(
             *config = load_config_with_overrides(&request_ctx.cli)?;
         } else {
             anyhow::bail!(crate::error::PrestoError::ConfigMissing(
-                "No wallet configured. Run 'presto login' to connect your wallet, then retry the request.".to_string()
+                "No wallet configured.".to_string()
             ));
         }
     }

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -24,15 +24,12 @@ pub struct SignerWithContext {
 ///
 /// Returns the signer along with the wallet address for keychain signing.
 pub fn load_signer_for_network(network: &str) -> Result<SignerWithContext> {
-    let creds = WalletCredentials::load().map_err(|_| {
-        PrestoError::ConfigMissing(
-            "No wallet configured. Run 'presto login' to get started.".to_string(),
-        )
-    })?;
+    let creds = WalletCredentials::load()
+        .map_err(|_| PrestoError::ConfigMissing("No wallet configured.".to_string()))?;
 
     if !creds.has_wallet() {
         return Err(PrestoError::ConfigMissing(
-            "No wallet configured. Run 'presto login' to get started.".to_string(),
+            "No wallet configured.".to_string(),
         ));
     }
 


### PR DESCRIPTION
## Summary
Remove duplicate "Run `presto login`" instruction from `ConfigMissing` error messages.

## Motivation
The error display system in `cli/errors.rs` already appends a `Fix: Run 'presto login' to set up your wallet.` line for all `ConfigMissing` errors. Having the same hint baked into the error message itself caused redundant output:

```
Error: Configuration missing: No wallet configured. Run 'presto login' to connect your wallet, then retry the request.

Fix: Run 'presto login' to set up your wallet.
```

## Changes
- `src/request.rs` — shorten message to `"No wallet configured."`
- `src/wallet/signer.rs` — same change in both call sites

## Testing
`make check` — all tests pass, clippy clean, fmt clean.