### PR TITLE
fix: wire PRESTO_RPC_URL and --rpc flag into config

### DIFF
--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -16,5 +16,14 @@ pub fn load_config(config_path: Option<impl AsRef<Path>>) -> Result<Config> {
 }
 
 pub fn load_config_with_overrides(cli: &Cli) -> Result<Config> {
-    load_config(cli.config.as_ref())
+    let mut config = load_config(cli.config.as_ref())?;
+
+    // Apply PRESTO_RPC_URL env var as a global RPC override.
+    // This is separate from clap's env handling on QueryArgs because it
+    // needs to apply to all commands (balance, whoami, etc.), not just queries.
+    if let Ok(rpc_url) = std::env::var("PRESTO_RPC_URL") {
+        config.set_rpc_override(rpc_url);
+    }
+
+    Ok(config)
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -83,6 +83,15 @@ impl Config {
         Ok(())
     }
 
+    /// Set a global RPC URL override that applies to all built-in networks.
+    ///
+    /// This is used by `PRESTO_RPC_URL` env var and the `--rpc` CLI flag.
+    /// The override takes precedence over config file settings.
+    pub fn set_rpc_override(&mut self, url: String) {
+        self.tempo_rpc = Some(url.clone());
+        self.moderato_rpc = Some(url);
+    }
+
     /// Resolve network information with config overrides applied.
     ///
     /// RPC overrides are resolved in order:

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use cli::{Cli, ColorMode, Commands, SessionCommands, Shell};
 use colored::control;
 
 use analytics::Analytics;
-use config::load_config;
+use config::load_config_with_overrides;
 
 /// Entry point for the presto CLI.
 ///
@@ -210,7 +210,7 @@ async fn handle_command(cli: Cli, command: Commands) -> Result<()> {
         }
 
         Commands::Balance { address } => {
-            let config = load_config(cli.config.as_ref())?;
+            let config = load_config_with_overrides(&cli)?;
             if let Some(ref a) = analytics {
                 a.track(
                     analytics::Event::BalanceChecked,

--- a/src/request.rs
+++ b/src/request.rs
@@ -29,6 +29,13 @@ use crate::payment::session::{handle_session_request, SessionResult};
 pub async fn make_request(cli: Cli, query: QueryArgs, analytics: Option<Analytics>) -> Result<()> {
     let mut config = load_config_with_overrides(&cli)?;
 
+    // Apply --rpc flag override from query args to config.
+    // The PRESTO_RPC_URL env var is already handled by load_config_with_overrides,
+    // but the explicit --rpc flag on QueryArgs takes final precedence.
+    if let Some(ref rpc_url) = query.rpc_url {
+        config.set_rpc_override(rpc_url.clone());
+    }
+
     let url = query.url.clone();
     let request_ctx = RequestContext::new(cli, query)?;
     let method_str = request_ctx.method.to_string();


### PR DESCRIPTION
## Problem

`PRESTO_RPC_URL` env var and the `--rpc` CLI flag were parsed by clap into `QueryArgs.rpc_url` but never applied to the `Config` used by payment and balance flows. All RPC calls used the built-in default URLs, silently ignoring the user's override.

## Fix

- Add `Config::set_rpc_override()` to apply a global RPC URL override to all built-in networks
- Apply `PRESTO_RPC_URL` in `load_config_with_overrides()` so it works for all commands (balance, whoami, query, etc.)
- Apply `--rpc` flag in `make_request()` for explicit per-query overrides (takes final precedence)
- Switch balance command from `load_config()` to `load_config_with_overrides()`

## Testing

All 361 existing tests pass. The fix is a config wiring change — the env var was already being parsed, it just wasn't being used.