### PR TITLE
increase auth timeout from 5m to 15m

### DIFF
--- a/src/wallet/manager.rs
+++ b/src/wallet/manager.rs
@@ -15,7 +15,7 @@ use crate::wallet::credentials::WalletCredentials;
 use crate::wallet::device_code::{create_device_code, poll_device_code};
 use crate::wallet::pkce;
 
-const CALLBACK_TIMEOUT_SECS: u64 = 300; // 5 minutes
+const CALLBACK_TIMEOUT_SECS: u64 = 900; // 15 minutes
 const POLL_INTERVAL_SECS: u64 = 2;
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
Increase the CLI authorization polling timeout from 5 minutes to 15 minutes. 

## Motivation
Many users will be funding for the first time which can reasonably take up to 15m.

## Changes
- `CALLBACK_TIMEOUT_SECS`: 300 → 900 in `src/wallet/manager.rs`

## Testing
`make check` — all 286 tests pass, no clippy warnings.