### PR TITLE
fix: retry gas estimation without key_authorization on KeyAlreadyExists

### DIFF
--- a/src/payment/providers/tempo/payment.rs
+++ b/src/payment/providers/tempo/payment.rs
@@ -7,7 +7,6 @@ use crate::payment::mpp_ext::TempoChargeExt;
 use alloy::primitives::{Address, U256};
 use tempo_primitives::transaction::Call;
 
-use super::gas::estimate_tempo_gas;
 use super::signing::SigningSetupContext;
 use super::swap::build_swap_calls;
 use super::transaction::{build_tempo_tx, sign_and_encode, TempoTxOptions};
@@ -46,7 +45,7 @@ pub async fn create_tempo_payment(
     config: &Config,
     challenge: &mpp::PaymentChallenge,
 ) -> Result<mpp::PaymentCredential> {
-    let ctx = PaymentSetupContext::from_challenge(config, challenge).await?;
+    let mut ctx = PaymentSetupContext::from_challenge(config, challenge).await?;
 
     let currency = ctx.charge_req.currency_address()?;
     let recipient = ctx.charge_req.recipient_address()?;
@@ -61,18 +60,7 @@ pub async fn create_tempo_payment(
         input: transfer_data,
     }];
 
-    let gas_limit = estimate_tempo_gas(
-        &ctx.signing.provider,
-        ctx.signing.from,
-        ctx.signing.chain_id,
-        ctx.signing.nonce,
-        currency,
-        &calls,
-        ctx.signing.gas_config.max_fee_per_gas_u128(),
-        ctx.signing.gas_config.max_priority_fee_per_gas_u128(),
-        ctx.signing.signing_mode.key_authorization(),
-    )
-    .await?;
+    let gas_limit = ctx.signing.estimate_gas(currency, &calls).await?;
 
     let tx = build_tempo_tx(TempoTxOptions {
         calls,
@@ -117,7 +105,7 @@ pub async fn create_tempo_payment_with_swap(
     challenge: &mpp::PaymentChallenge,
     swap_info: &SwapInfo,
 ) -> Result<mpp::PaymentCredential> {
-    let ctx = PaymentSetupContext::from_challenge(config, challenge).await?;
+    let mut ctx = PaymentSetupContext::from_challenge(config, challenge).await?;
 
     let recipient = ctx.charge_req.recipient_address()?;
     let amount = ctx.charge_req.amount_u256()?;
@@ -125,18 +113,7 @@ pub async fn create_tempo_payment_with_swap(
 
     let calls = build_swap_calls(swap_info, recipient, amount, memo)?;
 
-    let gas_limit = estimate_tempo_gas(
-        &ctx.signing.provider,
-        ctx.signing.from,
-        ctx.signing.chain_id,
-        ctx.signing.nonce,
-        swap_info.token_in,
-        &calls,
-        ctx.signing.gas_config.max_fee_per_gas_u128(),
-        ctx.signing.gas_config.max_priority_fee_per_gas_u128(),
-        ctx.signing.signing_mode.key_authorization(),
-    )
-    .await?;
+    let gas_limit = ctx.signing.estimate_gas(swap_info.token_in, &calls).await?;
 
     let tx = build_tempo_tx(TempoTxOptions {
         calls,
@@ -178,20 +155,9 @@ pub async fn create_tempo_payment_from_calls(
     calls: Vec<Call>,
     fee_token: Address,
 ) -> Result<mpp::PaymentCredential> {
-    let ctx = SigningSetupContext::from_challenge(config, challenge).await?;
+    let mut ctx = SigningSetupContext::from_challenge(config, challenge).await?;
 
-    let gas_limit = estimate_tempo_gas(
-        &ctx.provider,
-        ctx.from,
-        ctx.chain_id,
-        ctx.nonce,
-        fee_token,
-        &calls,
-        ctx.gas_config.max_fee_per_gas_u128(),
-        ctx.gas_config.max_priority_fee_per_gas_u128(),
-        ctx.signing_mode.key_authorization(),
-    )
-    .await?;
+    let gas_limit = ctx.estimate_gas(fee_token, &calls).await?;
 
     let tx = build_tempo_tx(TempoTxOptions {
         calls,

--- a/src/payment/providers/tempo/signing.rs
+++ b/src/payment/providers/tempo/signing.rs
@@ -23,6 +23,7 @@ pub(super) struct SigningSetupContext {
     pub gas_config: GasConfig,
     pub provider: HttpProvider,
     pub signing_mode: TempoSigningMode,
+    pub network_name: String,
 }
 
 impl SigningSetupContext {
@@ -221,6 +222,103 @@ impl SigningSetupContext {
             gas_config,
             provider,
             signing_mode,
+            network_name: network_name.to_string(),
         })
+    }
+
+    /// Estimate gas for a Tempo transaction, automatically retrying without
+    /// `key_authorization` if gas estimation fails with `KeyAlreadyExists`.
+    ///
+    /// This handles the case where the local `provisioned` flag is out of sync
+    /// with the on-chain state (key already provisioned but local wallet says
+    /// it isn't). On retry, the signing mode is updated in-place and the
+    /// provisioned flag is persisted to wallet.toml.
+    pub async fn estimate_gas(
+        &mut self,
+        fee_token: Address,
+        calls: &[tempo_primitives::transaction::Call],
+    ) -> Result<u64> {
+        use super::gas::estimate_tempo_gas;
+
+        let result = estimate_tempo_gas(
+            &self.provider,
+            self.from,
+            self.chain_id,
+            self.nonce,
+            fee_token,
+            calls,
+            self.gas_config.max_fee_per_gas_u128(),
+            self.gas_config.max_priority_fee_per_gas_u128(),
+            self.signing_mode.key_authorization(),
+        )
+        .await;
+
+        match result {
+            Ok(gas) => Ok(gas),
+            Err(e)
+                if self.signing_mode.key_authorization().is_some() && is_key_already_exists(&e) =>
+            {
+                debug!("access key already provisioned on-chain, retrying gas estimation without key_authorization");
+                self.drop_key_authorization();
+                estimate_tempo_gas(
+                    &self.provider,
+                    self.from,
+                    self.chain_id,
+                    self.nonce,
+                    fee_token,
+                    calls,
+                    self.gas_config.max_fee_per_gas_u128(),
+                    self.gas_config.max_priority_fee_per_gas_u128(),
+                    None,
+                )
+                .await
+                .map_err(Into::into)
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Strip key_authorization from signing mode and persist provisioned flag.
+    fn drop_key_authorization(&mut self) {
+        if let TempoSigningMode::Keychain {
+            key_authorization, ..
+        } = &mut self.signing_mode
+        {
+            *key_authorization = None;
+        }
+        crate::wallet::credentials::WalletCredentials::mark_provisioned(&self.network_name);
+    }
+}
+
+/// Check if an MppError is caused by a KeyAlreadyExists revert from the keychain precompile.
+fn is_key_already_exists(err: &mpp::MppError) -> bool {
+    err.to_string().contains("KeyAlreadyExists")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_key_already_exists_matches() {
+        let err = mpp::MppError::Http(
+            "gas estimation failed: server returned an error response: error code -32603: \
+             Revm error: keychain precompile error: Account keychain error: \
+             KeyAlreadyExists(KeyAlreadyExists)"
+                .to_string(),
+        );
+        assert!(is_key_already_exists(&err));
+    }
+
+    #[test]
+    fn test_is_key_already_exists_no_match() {
+        let err = mpp::MppError::Http("gas estimation failed: out of gas".to_string());
+        assert!(!is_key_already_exists(&err));
+    }
+
+    #[test]
+    fn test_is_key_already_exists_not_provisioned() {
+        let err = mpp::MppError::Tempo(mpp::client::TempoClientError::AccessKeyNotProvisioned);
+        assert!(!is_key_already_exists(&err));
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -205,16 +205,7 @@ fn is_not_provisioned(err: &anyhow::Error) -> bool {
 
 /// Mark a network as provisioned in wallet.toml after a successful payment.
 fn mark_network_provisioned(network: &str) {
-    if let Ok(mut creds) = crate::wallet::credentials::WalletCredentials::load() {
-        if let Some(key) = creds.network_key_mut(network) {
-            if !key.provisioned {
-                key.provisioned = true;
-                if let Err(e) = creds.save() {
-                    tracing::warn!("Failed to persist provisioned flag: {e}");
-                }
-            }
-        }
-    }
+    crate::wallet::credentials::WalletCredentials::mark_provisioned(network);
 }
 
 /// Parsed payment challenge context extracted from a 402 response.

--- a/src/wallet/credentials.rs
+++ b/src/wallet/credentials.rs
@@ -149,6 +149,22 @@ impl WalletCredentials {
         self.networks.get_mut(network)
     }
 
+    /// Mark a network's access key as provisioned and persist to disk.
+    ///
+    /// No-op if the key is already marked provisioned or the network doesn't exist.
+    pub fn mark_provisioned(network: &str) {
+        if let Ok(mut creds) = Self::load() {
+            if let Some(key) = creds.network_key_mut(network) {
+                if !key.provisioned {
+                    key.provisioned = true;
+                    if let Err(e) = creds.save() {
+                        tracing::warn!("failed to persist provisioned flag: {e}");
+                    }
+                }
+            }
+        }
+    }
+
     /// Clear the wallet credentials.
     pub fn clear(&mut self) {
         self.account_address.clear();


### PR DESCRIPTION
## Summary
Auto-retry gas estimation when the keychain precompile returns `KeyAlreadyExists`, fixing a crash when the local `provisioned` flag is out of sync with on-chain state.

## Motivation
When `wallet.toml` has `provisioned = false` but the access key is already provisioned on-chain (e.g., provisioned on another machine, or flag not persisted after a previous payment), presto includes a `key_authorization` in the transaction. Gas estimation then fails with:

```
Error: Invalid challenge: Gas estimation failed: ... KeyAlreadyExists(KeyAlreadyExists)
```

## Changes
- Add `SigningSetupContext::estimate_gas()` that wraps `estimate_tempo_gas` with `KeyAlreadyExists` detection and auto-retry (`src/payment/providers/tempo/signing.rs`)
- On retry: strips `key_authorization` from `signing_mode`, persists `provisioned = true` to `wallet.toml`, and re-estimates without the authorization
- All 3 gas estimation callsites in `payment.rs` now use `estimate_gas()` instead of calling `estimate_tempo_gas` directly
- Store `network_name` in `SigningSetupContext` so provisioned flag can be persisted correctly

## Testing
```
make check  # fmt, clippy, 271 tests, build — all pass
```