### PR TITLE
fix: show clean error for unknown commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,23 @@ fn parse_cli() -> Cli {
 
             let mut with_query = vec![args[0].clone(), "query".to_string()];
             with_query.extend(args[1..].iter().cloned());
-            Cli::try_parse_from(with_query).unwrap_or_else(|_| original_err.exit())
+            match Cli::try_parse_from(with_query) {
+                Ok(cli) => {
+                    // Re-parse succeeded. Check if the URL looks like a
+                    // mistyped command (no scheme, no dots, no localhost).
+                    // This catches `presto foo` and gives a clean error.
+                    if let Some(Commands::Query(ref q)) = cli.command {
+                        let url = &q.url;
+                        if !url.contains("://") && !url.contains("localhost") && !url.contains('.')
+                        {
+                            eprintln!("error: '{url}' is not a presto command. See 'presto --help' for a list of available commands.");
+                            ExitCode::InvalidUsage.exit();
+                        }
+                    }
+                    cli
+                }
+                Err(_) => original_err.exit(),
+            }
         }
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -348,6 +348,17 @@ fn test_typo_subcommand_not_swallowed() {
 }
 
 #[test]
+fn test_unknown_command_shows_clean_error() {
+    // `presto foo` should show a clean "not a command" error, not a URL parse error
+    Command::new(assert_cmd::cargo::cargo_bin!("presto"))
+        .args(["foo"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("is not a presto command"))
+        .stderr(predicate::str::contains("presto --help"));
+}
+
+#[test]
 fn test_bare_url_with_dry_run() {
     // `--dry-run` with a bare URL should succeed without making a payment
     Command::new(assert_cmd::cargo::cargo_bin!("presto"))


### PR DESCRIPTION
## Summary
Replaces the confusing URL parse error with a clear message when someone types an unknown command.

**Before:**
```
$ presto foo
Error: Invalid URL: 'foo' (relative URL without a base)
```

**After:**
```
$ presto foo
error: 'foo' is not a presto command. See 'presto --help' for a list of available commands.
```

## Changes
- After implicit `query` insertion succeeds in `parse_cli()`, check if the parsed URL looks like a mistyped command (no scheme, no dots, no `localhost`)
- Exits with code 2 (`InvalidUsage`) for consistency with other CLI arg errors

## Testing
- Added `test_unknown_command_shows_clean_error` integration test
- All 282 tests pass (`make check` clean)

Prompted by: varun