### PR TITLE
feat(cli): input validation and URL safety (allow only http/https; CRLF header guard)

### DIFF
--- a/src/cli/exit_codes.rs
+++ b/src/cli/exit_codes.rs
@@ -153,6 +153,9 @@ impl From<&crate::error::PrestoError> for ExitCode {
             | PrestoError::Signing(_)
             | PrestoError::InvalidAddress(_) => ExitCode::AuthError,
 
+            // Invalid arguments / user input
+            PrestoError::InvalidUrl(_) | PrestoError::InvalidHeader(_) => ExitCode::InvalidUsage,
+
             // General errors
             _ => ExitCode::GeneralError,
         }

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -50,8 +50,19 @@ pub async fn make_request(cli: Cli, query: QueryArgs, analytics: Option<Analytic
     let url = query.url.clone();
 
     // Validate the URL early to give a clear error instead of a cryptic reqwest message.
-    if let Err(e) = url::Url::parse(&url) {
-        anyhow::bail!("Invalid URL: '{url}' ({e})");
+    match url::Url::parse(&url) {
+        Ok(parsed) => {
+            let scheme = parsed.scheme();
+            if scheme != "http" && scheme != "https" {
+                anyhow::bail!(PrestoError::InvalidUrl(format!(
+                    "unsupported scheme '{}'",
+                    scheme
+                )));
+            }
+        }
+        Err(e) => {
+            anyhow::bail!(PrestoError::InvalidUrl(e.to_string()));
+        }
     }
 
     let request_ctx = build_request_context(&cli, &query)?;
@@ -622,6 +633,11 @@ fn display_receipt(
 fn build_request_context(cli: &Cli, query: &QueryArgs) -> Result<RequestContext> {
     for header in &query.headers {
         validate_header_size(header)?;
+        if header.contains('\r') || header.contains('\n') {
+            anyhow::bail!(PrestoError::InvalidHeader(
+                "header contains CR/LF characters".to_string()
+            ));
+        }
     }
 
     let runtime = RequestRuntime {

--- a/src/error.rs
+++ b/src/error.rs
@@ -74,6 +74,14 @@ pub(crate) enum PrestoError {
     #[error("Invalid address: {0}")]
     InvalidAddress(String),
 
+    /// Invalid URL provided
+    #[error("Invalid URL: {0}")]
+    InvalidUrl(String),
+
+    /// Invalid header (potential injection or malformed)
+    #[error("Invalid header: {0}")]
+    InvalidHeader(String),
+
     /// JSON serialization/deserialization error
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),

--- a/src/main.rs
+++ b/src/main.rs
@@ -523,12 +523,22 @@ fn init_color_support(cli: &Cli) {
 /// Parses CLI and loads config to determine the resolved `OutputFormat`.
 /// Returns `None` if parsing fails; defaults to text in that case.
 fn resolve_output_format_for_error() -> Option<config::OutputFormat> {
-    // Try to parse CLI normally; do not attempt the query fallback here to
-    // avoid ambiguity on parse errors.
+    // Try to parse CLI normally first
     if let Ok(cli) = Cli::try_parse() {
-        // Load config (best-effort) and resolve format
         let cfg = load_config_with_overrides(cli.config.as_ref()).unwrap_or_default();
         return Some(cli.resolve_output_format(&cfg));
     }
+
+    // If normal parsing failed, try the same fallback as parse_cli(): insert "query"
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() > 1 {
+        let mut with_query = vec![args[0].clone(), "query".to_string()];
+        with_query.extend(args[1..].iter().cloned());
+        if let Ok(cli) = Cli::try_parse_from(with_query) {
+            let cfg = load_config_with_overrides(cli.config.as_ref()).unwrap_or_default();
+            return Some(cli.resolve_output_format(&cfg));
+        }
+    }
+
     None
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -576,6 +576,47 @@ fn test_json_error_output_for_network_error() {
     assert!(val.get("code").is_some());
     assert!(val.get("message").is_some());
 }
+
+// ==================== Input Validation Tests ====================
+
+#[test]
+fn test_rejects_file_url_with_json_error() {
+    let temp = TestConfigBuilder::new().build();
+    let mut cmd = test_command(&temp);
+    cmd.args(["-j", "query", "file:///etc/hosts"]);
+    let output = cmd.output().expect("failed to run");
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let val: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid json error");
+    assert_eq!(val.get("code").and_then(|v| v.as_str()), Some("E_USAGE"));
+}
+
+#[test]
+fn test_rejects_data_url_with_json_error() {
+    let temp = TestConfigBuilder::new().build();
+    let mut cmd = test_command(&temp);
+    cmd.args(["-j", "query", "data:text/plain,hi"]);
+    let output = cmd.output().expect("failed to run");
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let val: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid json error");
+    assert_eq!(val.get("code").and_then(|v| v.as_str()), Some("E_USAGE"));
+}
+
+#[test]
+fn test_rejects_header_with_crlf_injection() {
+    let temp = TestConfigBuilder::new().build();
+    let mut cmd = test_command(&temp);
+    // Embed a CRLF in a single -H argument to simulate header injection
+    let bad_header = format!("X-Test: good\r\nInjected: bad");
+    cmd.args(["-j", "-H", &bad_header, "http://example.com"]);
+    let output = cmd.output().expect("failed to run");
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let val: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid json error");
+    assert_eq!(val.get("code").and_then(|v| v.as_str()), Some("E_USAGE"));
+}
+
 // ==================== Key Management Tests ====================
 
 /// Helper: write a multi-key keys.toml into both macOS and Linux paths.


### PR DESCRIPTION
This PR adds input validation for safer defaults and agent-friendly errors.

Behavior
- URL schemes: allow only http/https. Reject others (e.g., file:, data:) with E_USAGE. With , emit structured JSON error on stdout.
- Header guard: reject header names/values containing CR or LF to prevent header injection (E_USAGE).
- Localhost: allowed by default (no blocking).

Implementation
- New errors: , .
- Exit code mapping: both → E_USAGE.
- Validation staged before request execution in .

Tests
-  and  URLs are rejected with JSON  when  is set.
- CRLF in a  header is rejected with JSON .

No changes to payment/streaming flows. All tests pass via cargo fmt --check
cargo clippy -- -D warnings
cargo test -- --quiet

running 186 tests
....................................................................................... 87/186
......................................................................i................ 174/186
............
test result: ok. 185 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.09s


running 71 tests
.......................................................................
test result: ok. 71 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.58s


running 5 tests
iiiii
test result: ok. 0 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 32 tests
................................
test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.34s

cargo build.