### PR TITLE
fix: release signing job auth for private git deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Configure git for private repos
+        run: git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
       - uses: actions/download-artifact@v8
         with:
           path: artifacts


### PR DESCRIPTION
## Summary
- add private git auth setup to the `release` job in `.github/workflows/release.yml`
- mirror build-job auth so `cargo run --bin sign-release` can fetch private git deps

## Why
Release failed in `Sign release binaries` due to auth failure fetching `https://github.com/tempoxyz/mpp-rs.git`:
- https://github.com/tempoxyz/wallet/actions/runs/22741709626/job/65957366100

## Change
- insert this step immediately after checkout in the release job:
  - `git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"`

## Risk
Low: aligns release-job credential behavior with already-working build jobs.
