### PR TITLE
feat: add `tempo mpp sign` command for offline challenge signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6494,6 +6494,7 @@ dependencies = [
  "axum",
  "clap",
  "clap_complete",
+ "mpp",
  "predicates",
  "reqwest 0.12.28",
  "rusqlite",

--- a/crates/tempo-mpp/Cargo.toml
+++ b/crates/tempo-mpp/Cargo.toml
@@ -18,6 +18,7 @@ tempo-common = { path = "../tempo-common" }
 alloy.workspace = true
 anyhow.workspace = true
 clap.workspace = true
+mpp.workspace = true
 clap_complete.workspace = true
 reqwest.workspace = true
 serde.workspace = true

--- a/crates/tempo-mpp/src/app.rs
+++ b/crates/tempo-mpp/src/app.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 
 use crate::args::{Cli, Commands, ServicesCommands, SessionCommands};
-use crate::commands::{completions, services, sessions};
+use crate::commands::{completions, services, sessions, sign};
 
 /// Run the tempo-mpp application.
 pub(crate) async fn run(mut cli: Cli) -> Result<()> {
@@ -20,6 +20,7 @@ pub(crate) async fn run(mut cli: Cli) -> Result<()> {
         tempo_common::cli::tracking::track_command(&ctx.analytics, cmd_name);
         let result = match command {
             Commands::Completions { shell } => completions::run(&ctx, shell),
+            Commands::Sign { challenge, dry_run } => sign::run(&ctx, challenge, dry_run).await,
             Commands::Sessions { command } => sessions::run(&ctx, command).await,
             Commands::Services {
                 command,
@@ -48,6 +49,7 @@ pub(crate) async fn run(mut cli: Cli) -> Result<()> {
 fn command_name(command: &Commands) -> &'static str {
     match command {
         Commands::Completions { .. } => "completions",
+        Commands::Sign { .. } => "sign",
         Commands::Sessions { command } => match command {
             SessionCommands::List { .. } => "sessions list",
             SessionCommands::Info { .. } => "sessions info",

--- a/crates/tempo-mpp/src/args.rs
+++ b/crates/tempo-mpp/src/args.rs
@@ -68,6 +68,24 @@ pub(crate) enum Commands {
         search: Option<String>,
     },
 
+    /// Sign an MPP payment challenge and output the Authorization header
+    ///
+    /// Reads a WWW-Authenticate header value (the Payment challenge from a 402
+    /// response), runs the full Tempo signing flow, and prints the Authorization
+    /// header value ready to send.
+    ///
+    /// The challenge can be passed via --challenge or piped through stdin.
+    #[command(display_order = 3, name = "sign")]
+    Sign {
+        /// Pass the WWW-Authenticate challenge value directly
+        #[arg(long, value_name = "VALUE")]
+        challenge: Option<String>,
+
+        /// Validate and parse the challenge without signing
+        #[arg(long)]
+        dry_run: bool,
+    },
+
     /// Generate shell completions script
     #[command(hide = true)]
     Completions {

--- a/crates/tempo-mpp/src/commands/mod.rs
+++ b/crates/tempo-mpp/src/commands/mod.rs
@@ -3,3 +3,4 @@
 pub(crate) mod completions;
 pub(crate) mod services;
 pub(crate) mod sessions;
+pub(crate) mod sign;

--- a/crates/tempo-mpp/src/commands/sign.rs
+++ b/crates/tempo-mpp/src/commands/sign.rs
@@ -1,0 +1,107 @@
+//! Sign an MPP payment challenge and output the Authorization header value.
+
+use std::io::{self, Read};
+
+use anyhow::{Context as _, Result};
+use mpp::client::PaymentProvider;
+use mpp::protocol::methods::tempo::TempoChargeExt;
+
+use tempo_common::cli::context::Context;
+use tempo_common::cli::output::OutputFormat;
+use tempo_common::error::{ConfigError, PaymentError};
+use tempo_common::network::NetworkId;
+use tempo_common::payment::error::{classify_payment_error, map_mpp_validation_error};
+
+/// Run the `sign` subcommand.
+pub(crate) async fn run(ctx: &Context, challenge_arg: Option<String>, dry_run: bool) -> Result<()> {
+    let raw = read_challenge(challenge_arg)?;
+    let challenge =
+        mpp::parse_www_authenticate(&raw).context("Failed to parse WWW-Authenticate challenge")?;
+
+    // Enforce supported payment protocol
+    if !challenge.method.eq_ignore_ascii_case("tempo") {
+        return Err(PaymentError::UnsupportedPaymentMethod(challenge.method.to_string()).into());
+    }
+
+    // Resolve network from challenge
+    let network = if let Ok(charge) = challenge.request.decode::<mpp::ChargeRequest>() {
+        require_chain(charge.chain_id())?
+    } else if let Ok(session) = challenge.request.decode::<mpp::SessionRequest>() {
+        use mpp::protocol::methods::tempo::session::TempoSessionExt;
+        require_chain(session.chain_id())?
+    } else {
+        return Err(PaymentError::InvalidChallenge(
+            "unsupported payment challenge payload".to_string(),
+        )
+        .into());
+    };
+
+    // Validate challenge
+    challenge
+        .validate_for_charge("tempo")
+        .map_err(|e| map_mpp_validation_error(e, &challenge))?;
+
+    if dry_run {
+        eprintln!("Challenge is valid.");
+        return Ok(());
+    }
+
+    // Sign
+    let signer = ctx.keys.signer(network)?;
+    let from = signer.from;
+    let rpc_url = ctx.config.rpc_url(network);
+
+    let provider = mpp::client::TempoProvider::new(signer.signer.clone(), rpc_url.as_str())
+        .map_err(|e| ConfigError::Invalid(e.to_string()))?
+        .with_signing_mode(signer.signing_mode);
+
+    let credential = provider
+        .pay(&challenge)
+        .await
+        .map_err(|e| classify_payment_error(e, &network))?;
+
+    let auth_header =
+        mpp::format_authorization(&credential).context("Failed to format Authorization header")?;
+
+    // Output
+    match ctx.output_format {
+        OutputFormat::Json | OutputFormat::Toon => {
+            let payload = serde_json::json!({
+                "authorization": auth_header,
+                "from": format!("{:#x}", from),
+            });
+            tempo_common::cli::output::emit_structured(ctx.output_format, &payload)?;
+        }
+        OutputFormat::Text => {
+            println!("{auth_header}");
+        }
+    }
+
+    Ok(())
+}
+
+/// Read the challenge from --challenge flag or stdin.
+fn read_challenge(flag: Option<String>) -> Result<String> {
+    if let Some(value) = flag {
+        return Ok(value);
+    }
+
+    let mut buf = String::new();
+    io::stdin()
+        .read_to_string(&mut buf)
+        .context("Failed to read challenge from stdin")?;
+    let trimmed = buf.trim().to_string();
+    if trimmed.is_empty() {
+        anyhow::bail!("No challenge provided. Use --challenge or pipe via stdin.");
+    }
+    Ok(trimmed)
+}
+
+/// Resolve a chain ID to a known `NetworkId`.
+fn require_chain(chain_id: Option<u64>) -> Result<NetworkId> {
+    let cid = chain_id.ok_or_else(|| {
+        PaymentError::InvalidChallenge("missing chainId in payment request".to_string())
+    })?;
+    NetworkId::from_chain_id(cid)
+        .ok_or_else(|| PaymentError::InvalidChallenge(format!("unsupported chainId: {cid}")).into())
+}

--- a/crates/tempo-mpp/tests/cli.rs
+++ b/crates/tempo-mpp/tests/cli.rs
@@ -1,6 +1,15 @@
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
-use std::process::Command;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+mod common;
+use common::{test_command, TestConfigBuilder};
+
+/// Valid charge challenge for Tempo mainnet (chainId 4217).
+///
+/// request = base64url({"amount":"1000","currency":"0x20c000000000000000000000b9537d11c60e8b50","methodDetails":{"chainId":4217}})
+const VALID_CHARGE_CHALLENGE: &str = r#"Payment id="test", realm="test", method="tempo", intent="charge", request="eyJhbW91bnQiOiIxMDAwIiwiY3VycmVuY3kiOiIweDIwYzAwMDAwMDAwMDAwMDAwMDAwMDAwMGI5NTM3ZDExYzYwZThiNTAiLCJtZXRob2REZXRhaWxzIjp7ImNoYWluSWQiOjQyMTd9fQ""#;
 
 #[test]
 fn mpp_help_includes_mpp_commands() {
@@ -9,7 +18,8 @@ fn mpp_help_includes_mpp_commands() {
         .assert()
         .success()
         .stdout(predicate::str::contains("sessions"))
-        .stdout(predicate::str::contains("services"));
+        .stdout(predicate::str::contains("services"))
+        .stdout(predicate::str::contains("sign"));
 }
 
 #[test]
@@ -19,4 +29,99 @@ fn mpp_rejects_unknown_subcommand() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("unrecognized"));
+}
+
+#[test]
+fn sign_help_shows_flags() {
+    Command::new(assert_cmd::cargo::cargo_bin!("tempo-mpp"))
+        .args(["sign", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--challenge"))
+        .stdout(predicate::str::contains("--dry-run"));
+}
+
+#[test]
+fn sign_dry_run_valid_challenge() {
+    let temp = TestConfigBuilder::new().build();
+    let mut cmd = test_command(&temp);
+    cmd.args(["sign", "--dry-run", "--challenge", VALID_CHARGE_CHALLENGE]);
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::contains("Challenge is valid"));
+}
+
+#[test]
+fn sign_dry_run_invalid_challenge() {
+    let temp = TestConfigBuilder::new().build();
+    let mut cmd = test_command(&temp);
+    cmd.args(["sign", "--dry-run", "--challenge", "not a valid challenge"]);
+    cmd.assert().failure();
+}
+
+#[test]
+fn sign_dry_run_unsupported_method() {
+    let temp = TestConfigBuilder::new().build();
+    let challenge = r#"Payment id="x", realm="x", method="stripe", intent="charge", request="e30""#;
+    let mut cmd = test_command(&temp);
+    cmd.args(["sign", "--dry-run", "--challenge", challenge]);
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Unsupported"));
+}
+
+#[test]
+fn sign_dry_run_missing_chain_id() {
+    let temp = TestConfigBuilder::new().build();
+    // request = base64url({"amount":"1000","currency":"0x00"}) — no methodDetails/chainId
+    let challenge = r#"Payment id="x", realm="x", method="tempo", intent="charge", request="eyJhbW91bnQiOiIxMDAwIiwiY3VycmVuY3kiOiIweDAwIn0""#;
+    let mut cmd = test_command(&temp);
+    cmd.args(["sign", "--dry-run", "--challenge", challenge]);
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("chainId"));
+}
+
+#[test]
+fn sign_no_wallet_configured() {
+    let temp = TestConfigBuilder::new().build();
+    let mut cmd = test_command(&temp);
+    cmd.args(["sign", "--challenge", VALID_CHARGE_CHALLENGE]);
+    cmd.assert().failure();
+}
+
+#[test]
+fn sign_empty_stdin_fails() {
+    let temp = TestConfigBuilder::new().build();
+    let mut cmd = test_command(&temp);
+    cmd.arg("sign");
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn().expect("Failed to spawn");
+    drop(child.stdin.take()); // close stdin immediately
+    let output = child.wait_with_output().expect("Failed to wait");
+    assert!(!output.status.success());
+}
+
+#[test]
+fn sign_dry_run_reads_from_stdin() {
+    let temp = TestConfigBuilder::new().build();
+    let mut cmd = test_command(&temp);
+    cmd.args(["sign", "--dry-run"]);
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn().expect("Failed to spawn");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(VALID_CHARGE_CHALLENGE.as_bytes())
+        .unwrap();
+    drop(child.stdin.take());
+    let output = child.wait_with_output().expect("Failed to wait");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "sign via stdin failed: {stderr}");
+    assert!(stderr.contains("Challenge is valid"), "stderr: {stderr}");
 }


### PR DESCRIPTION
## Summary

Add a `sign` subcommand to `tempo mpp` that takes an MPP payment challenge as input, runs the full Tempo signing flow, and outputs the Authorization header value.

## Usage

```bash
# Via --challenge flag
tempo mpp sign --challenge 'Payment id="...", realm="...", method="tempo", intent="charge", request="..."'

# Via stdin pipe
echo '<www-authenticate-value>' | tempo mpp sign

# Dry-run validation
tempo mpp sign --dry-run --challenge '<challenge>'

# JSON output
tempo mpp sign -j --challenge '<challenge>'
# {"authorization":"Payment ...","from":"0x..."}
```

## Flags

| Flag | Description |
|------|-------------|
| `--challenge <VALUE>` | Pass challenge directly instead of stdin |
| `--dry-run` | Validate and parse the challenge without signing |
| `-j` / `-t` | Structured output with `authorization` and `from` fields |
| Standard global flags | `--network`, `--private-key`, `--rpc`, etc. |

## Tests

8 new integration tests:
- Help text verification
- Dry-run with valid/invalid challenges
- Unsupported method rejection
- Missing chainId rejection
- Missing wallet error
- Empty stdin error
- Stdin pipe input