### PR TITLE
feat: set client_id on TempoProvider for MPP attribution

### DIFF
--- a/crates/tempo-mpp/src/commands/sign.rs
+++ b/crates/tempo-mpp/src/commands/sign.rs
@@ -53,7 +53,8 @@ pub(crate) async fn run(ctx: &Context, challenge_arg: Option<String>, dry_run: b
 
     let provider = mpp::client::TempoProvider::new(signer.signer.clone(), rpc_url.as_str())
         .map_err(|e| ConfigError::Invalid(e.to_string()))?
-        .with_signing_mode(signer.signing_mode);
+        .with_signing_mode(signer.signing_mode)
+        .with_client_id("tempo-cli");
 
     let credential = provider
         .pay(&challenge)

--- a/crates/tempo-request/src/payment/charge.rs
+++ b/crates/tempo-request/src/payment/charge.rs
@@ -32,7 +32,8 @@ pub(super) async fn handle_charge_request(
     let provider =
         mpp::client::TempoProvider::new(signer.signer.clone(), resolved.rpc_url.as_str())
             .map_err(|e| ConfigError::Invalid(e.to_string()))?
-            .with_signing_mode(signer.signing_mode);
+            .with_signing_mode(signer.signing_mode)
+            .with_client_id("tempo-cli");
 
     let credential = provider
         .pay(challenge)


### PR DESCRIPTION
## Summary
Pass `tempo-cli` as `client_id` when creating `TempoProvider` instances so auto-generated attribution memos identify the CLI as the payment client.

## Motivation
Depends on [tempoxyz/mpp-rs#107](https://github.com/tempoxyz/mpp-rs/pull/107) which adds auto-generation of MPP attribution memos in `TempoProvider::pay()`. This PR ensures the CLI identifies itself so the attribution memo includes a client fingerprint.

## Changes
- `crates/tempo-request/src/payment/charge.rs` — added `.with_client_id("tempo-cli")`
- `crates/tempo-mpp/src/commands/sign.rs` — added `.with_client_id("tempo-cli")`

## Testing
```bash
cargo check                                           # clean
cargo clippy --workspace --all-targets -- -D warnings  # clean
```

Co-Authored-By: Alex Risch <23103150+alexrisch@users.noreply.github.com>

Prompted by: alex