### PR TITLE
feat: add comment-based trigger for cyclops PR audits

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -3,6 +3,8 @@ name: PR Audit
 on:
   pull_request:
     types: [labeled]
+  issue_comment:
+    types: [created]
 
 jobs:
   pr-audit:


### PR DESCRIPTION
## Summary
Add `cyclops review` PR comment as an alternative trigger for Cyclops audits.

## Changes
- Added `issue_comment` event trigger alongside existing `pull_request: [labeled]`
- Comment handling logic lives in the reusable workflow ([gh-actions#4](https://github.com/tempoxyz/gh-actions/pull/4))

Prompted by: tanishk