### PR TITLE
feat: macOS Secure Enclave wallet support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,58 @@ jobs:
           GIT_CONFIG_VALUE_0: https://github.com/
         run: cargo build --release --target ${{ matrix.target }} -p ${{ matrix.package }}
       - run: strip target/${{ matrix.target }}/release/${{ matrix.binary }}
+
+      - name: Codesign macOS binary
+        if: runner.os == 'macOS' && env.APPLE_CERT_P12 != ''
+        env:
+          APPLE_CERT_P12: ${{ secrets.APPLE_CERT_P12 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+        run: |
+          # Import Developer ID certificate into a temporary keychain
+          KEYCHAIN="build.keychain"
+          KEYCHAIN_PASSWORD="ci-build"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security default-keychain -s "$KEYCHAIN"
+          security list-keychains -s "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+
+          echo "$APPLE_CERT_P12" | base64 -d > /tmp/cert.p12
+          security import /tmp/cert.p12 -k "$KEYCHAIN" -P "$APPLE_CERT_PASSWORD" -A
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          rm /tmp/cert.p12
+
+          # Sign with Developer ID + entitlements + hardened runtime
+          codesign --force \
+            --sign "Developer ID Application: Tempo Technologies Inc." \
+            --entitlements assets/entitlements.plist \
+            --options runtime \
+            --timestamp \
+            "target/${{ matrix.target }}/release/${{ matrix.binary }}"
+
       - run: mv target/${{ matrix.target }}/release/${{ matrix.binary }} ${{ matrix.asset }}
+
+      - name: Notarize macOS binary
+        if: runner.os == 'macOS' && env.APPLE_API_KEY_DATA != ''
+        env:
+          APPLE_API_KEY_DATA: ${{ secrets.APPLE_API_KEY_DATA }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        run: |
+          # Prepare API key for notarytool
+          mkdir -p ~/.private_keys
+          echo -n "$APPLE_API_KEY_DATA" > ~/.private_keys/AuthKey_${APPLE_API_KEY_ID}.p8
+
+          # Notarize requires a zip archive
+          ditto -c -k "${{ matrix.asset }}" "${{ matrix.asset }}.zip"
+          xcrun notarytool submit "${{ matrix.asset }}.zip" \
+            --key ~/.private_keys/AuthKey_${APPLE_API_KEY_ID}.p8 \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER" \
+            --wait
+
+          rm "${{ matrix.asset }}.zip"
+          rm -rf ~/.private_keys
+
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 rusqlite = { version = "0.35", features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-security-framework = "3"
+security-framework = { version = "3", features = ["OSX_10_15"] }
 sha2 = "0.10"
 tempfile = "3.24"
 tempo-primitives = { git = "https://github.com/tempoxyz/tempo.git", features = ["serde"] }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build release clean check test fix install uninstall
+.PHONY: build release clean check test fix install uninstall sign
 
 build:
 	cargo build
@@ -34,6 +34,14 @@ check:
 fix:
 	cargo fmt
 	cargo clippy --fix --allow-dirty --allow-staged
+
+# Sign macOS debug binaries for Secure Enclave access (requires Apple Developer cert).
+# Usage: make sign IDENTITY="Developer ID Application: Your Name (TEAMID)"
+sign: build
+	@if [ -z "$(IDENTITY)" ]; then echo "Usage: make sign IDENTITY=\"Developer ID Application: ...\""; exit 1; fi
+	codesign --force --sign "$(IDENTITY)" --entitlements assets/entitlements.plist --options runtime target/debug/tempo-wallet
+	codesign --force --sign "$(IDENTITY)" --entitlements assets/entitlements.plist --options runtime target/debug/tempo-mpp
+	codesign --force --sign "$(IDENTITY)" --entitlements assets/entitlements.plist --options runtime target/debug/tempo-request
 
 # Generate coverage locally (requires cargo-llvm-cov and llvm-tools-preview)
 # Install once: `rustup component add llvm-tools-preview` and `cargo install cargo-llvm-cov`

--- a/assets/entitlements.plist
+++ b/assets/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.smartcard</key>
+    <true/>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)xyz.tempo.wallet</string>
+    </array>
+</dict>
+</plist>

--- a/crates/tempo-common/src/keys/keystore.rs
+++ b/crates/tempo-common/src/keys/keystore.rs
@@ -47,8 +47,15 @@ impl Keystore {
 
     /// Get the primary key entry.
     ///
-    /// Deterministic selection: passkey > first key with a signing key > first entry.
+    /// Deterministic selection: secure_enclave > passkey > first key with a signing key > first entry.
     pub fn primary_key(&self) -> Option<&KeyEntry> {
+        if let Some(entry) = self
+            .keys
+            .iter()
+            .find(|k| k.wallet_type == WalletType::SecureEnclave)
+        {
+            return Some(entry);
+        }
         if let Some(entry) = self
             .keys
             .iter()
@@ -72,7 +79,8 @@ impl Keystore {
     /// an inline `key`.
     pub fn has_wallet(&self) -> bool {
         self.primary_key().is_some_and(|a| {
-            !a.wallet_address.is_empty() && a.key.as_ref().is_some_and(|k| !k.is_empty())
+            !a.wallet_address.is_empty()
+                && (a.key.as_ref().is_some_and(|k| !k.is_empty()) || a.se_key_label.is_some())
         })
     }
 
@@ -132,6 +140,14 @@ impl Keystore {
         if let Some(entry) = self.keys.iter().find(|k| k.chain_id == chain_id) {
             return Some(entry);
         }
+        // SE keys with matching chain_id (checked above), then any SE with se_key_label
+        if let Some(entry) = self
+            .keys
+            .iter()
+            .find(|k| k.wallet_type == WalletType::SecureEnclave && k.se_key_label.is_some())
+        {
+            return Some(entry);
+        }
         // Direct EOA keys (wallet == signer) work on any network
         self.keys.iter().find(|k| {
             k.wallet_type == WalletType::Local
@@ -161,6 +177,13 @@ impl Keystore {
             .find(|k| k.wallet_type == WalletType::Passkey)
     }
 
+    /// Find the first Secure Enclave wallet entry, if one exists.
+    pub fn find_se_wallet(&self) -> Option<&KeyEntry> {
+        self.keys
+            .iter()
+            .find(|k| k.wallet_type == WalletType::SecureEnclave)
+    }
+
     /// Delete all passkey entries for a given wallet address (case-insensitive).
     ///
     /// Removes all entries where wallet_type is Passkey and wallet_address matches.
@@ -174,6 +197,22 @@ impl Keystore {
         if self.keys.len() == before {
             return Err(ConfigError::Missing(format!(
                 "No passkey wallet found for '{wallet_address}'."
+            ))
+            .into());
+        }
+        Ok(())
+    }
+
+    /// Delete all Secure Enclave entries for a given wallet address (case-insensitive).
+    pub fn delete_se_wallet(&mut self, wallet_address: &str) -> Result<(), TempoError> {
+        let before = self.keys.len();
+        self.keys.retain(|k| {
+            !(k.wallet_type == WalletType::SecureEnclave
+                && k.wallet_address.eq_ignore_ascii_case(wallet_address))
+        });
+        if self.keys.len() == before {
+            return Err(ConfigError::Missing(format!(
+                "No Secure Enclave wallet found for '{wallet_address}'."
             ))
             .into());
         }

--- a/crates/tempo-common/src/keys/mod.rs
+++ b/crates/tempo-common/src/keys/mod.rs
@@ -4,9 +4,11 @@ pub mod authorization;
 mod io;
 mod keystore;
 mod model;
+#[cfg(target_os = "macos")]
+pub mod secure_enclave;
 mod signer;
 
 pub use keystore::Keystore;
-pub use model::{KeyEntry, WalletType};
-use model::{KeyType, StoredTokenLimit};
+use model::StoredTokenLimit;
+pub use model::{KeyEntry, KeyType, WalletType};
 pub use signer::{parse_private_key_signer, Signer};

--- a/crates/tempo-common/src/keys/model.rs
+++ b/crates/tempo-common/src/keys/model.rs
@@ -10,6 +10,8 @@ pub enum WalletType {
     #[default]
     Local,
     Passkey,
+    #[serde(rename = "secure_enclave")]
+    SecureEnclave,
 }
 
 impl WalletType {
@@ -17,6 +19,7 @@ impl WalletType {
         match self {
             Self::Local => "local",
             Self::Passkey => "passkey",
+            Self::SecureEnclave => "secure_enclave",
         }
     }
 }
@@ -62,6 +65,10 @@ pub struct KeyEntry {
     /// Wrapped in [`Zeroizing`] so the secret is scrubbed from memory on drop.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key: Option<Zeroizing<String>>,
+    /// Secure Enclave key label (macOS only).
+    /// Used to locate the SE-backed private key; no raw key material is stored.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub se_key_label: Option<String>,
     /// Key authorization (RLP-encoded SignedKeyAuthorization hex).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key_authorization: Option<String>,
@@ -85,6 +92,7 @@ impl std::fmt::Debug for KeyEntry {
             .field("key_type", &self.key_type)
             .field("key_address", &self.key_address)
             .field("key", &self.key.as_ref().map(|_| "<redacted>"))
+            .field("se_key_label", &self.se_key_label)
             .field("key_authorization", &self.key_authorization)
             .field("expiry", &self.expiry)
             .field("limits", &self.limits)
@@ -126,6 +134,7 @@ mod tests {
             key_address: Some("0xdef".to_string()),
             key: Some(Zeroizing::new("0xsecret".to_string())),
             key_authorization: Some("0xauth".to_string()),
+            se_key_label: None,
             expiry: Some(1700000000),
             limits: vec![StoredTokenLimit {
                 currency: "0xUSDC".to_string(),
@@ -159,6 +168,7 @@ mod tests {
             key_address: None,
             key: None,
             key_authorization: None,
+            se_key_label: None,
             expiry: None,
             limits: vec![],
             provisioned: false,

--- a/crates/tempo-common/src/keys/secure_enclave.rs
+++ b/crates/tempo-common/src/keys/secure_enclave.rs
@@ -1,0 +1,391 @@
+//! macOS Secure Enclave P256 key management.
+//!
+//! Generates, loads, signs with, and deletes non-extractable P256 keys
+//! backed by the Secure Enclave. Requires macOS with a T2 or Apple
+//! Silicon chip and a binary signed with an Apple Developer identity
+//! (ad-hoc signing is not sufficient for Data Protection Keychain access).
+
+use security_framework::access_control::{ProtectionMode, SecAccessControl};
+use security_framework::item::{
+    ItemClass, ItemSearchOptions, KeyClass, Location, Reference, SearchResult,
+};
+use security_framework::key::{Algorithm, GenerateKeyOptions, KeyType, SecKey, Token};
+
+use crate::error::{KeyError, TempoError};
+
+// SecAccessControl flag constants (from Security.framework).
+// Raw values match kSecAccessControlBiometryAny and kSecAccessControlPrivateKeyUsage.
+const BIOMETRY_ANY: usize = 1 << 1;
+const PRIVATE_KEY_USAGE: usize = 1 << 30;
+
+/// Keychain label prefix for Tempo SE keys.
+const LABEL_PREFIX: &str = "xyz.tempo.wallet.se";
+
+/// Build a deterministic label for a Secure Enclave key.
+///
+/// Format: `xyz.tempo.wallet.se.<suffix>` where suffix is typically
+/// a short identifier like the wallet address.
+pub fn key_label(suffix: &str) -> String {
+    format!("{LABEL_PREFIX}.{suffix}")
+}
+
+/// Generate a new P256 key in the Secure Enclave.
+///
+/// The key is persisted in the Data Protection Keychain under the given
+/// `label` with biometric protection: Touch ID (or device passcode
+/// fallback) is required for every signing operation.
+///
+/// Requires a binary signed with an Apple Developer identity (ad-hoc
+/// signing is not sufficient for Data Protection Keychain access).
+///
+/// Returns the uncompressed X9.63 public key bytes (65 bytes: `04 || X || Y`).
+pub fn generate(label: &str) -> Result<Vec<u8>, TempoError> {
+    let ac = SecAccessControl::create_with_protection(
+        Some(ProtectionMode::AccessibleWhenUnlockedThisDeviceOnly),
+        PRIVATE_KEY_USAGE | BIOMETRY_ANY,
+    )
+    .map_err(|e| KeyError::Keychain(format!("Failed to create access control: {e}")))?;
+
+    let key = SecKey::new(
+        GenerateKeyOptions::default()
+            .set_key_type(KeyType::ec_sec_prime_random())
+            .set_size_in_bits(256)
+            .set_token(Token::SecureEnclave)
+            .set_label(label)
+            .set_location(Location::DataProtectionKeychain)
+            .set_access_control(ac),
+    )
+    .map_err(|e| KeyError::Keychain(format!("Failed to generate SE key: {e}")))?;
+
+    extract_public_key_bytes(&key)
+}
+
+/// Load an existing Secure Enclave key by its label.
+///
+/// Returns the `SecKey` handle for signing operations.
+pub fn load(label: &str) -> Result<SecKey, TempoError> {
+    let results = ItemSearchOptions::new()
+        .class(ItemClass::key())
+        .key_class(KeyClass::private())
+        .label(label)
+        .load_refs(true)
+        .limit(1)
+        .search()
+        .map_err(|e| KeyError::Keychain(format!("Failed to search for SE key: {e}")))?;
+
+    match results.into_iter().next() {
+        Some(SearchResult::Ref(Reference::Key(k))) => Ok(k),
+        _ => Err(KeyError::Keychain(format!("SE key not found: {label}")).into()),
+    }
+}
+
+/// Sign a SHA-256 digest with a Secure Enclave key.
+///
+/// Uses `ECDSASignatureDigestX962SHA256`: the caller provides the
+/// 32-byte SHA-256 hash and the SE signs it directly (no double-hash).
+///
+/// Returns the DER-encoded ECDSA signature.
+pub fn sign(key: &SecKey, digest: &[u8]) -> Result<Vec<u8>, TempoError> {
+    if digest.len() != 32 {
+        return Err(KeyError::Signing(format!(
+            "Expected 32-byte SHA-256 digest, got {} bytes",
+            digest.len()
+        ))
+        .into());
+    }
+    key.create_signature(Algorithm::ECDSASignatureDigestX962SHA256, digest)
+        .map_err(|e| KeyError::Signing(format!("SE signing failed: {e}")).into())
+}
+
+/// Delete a Secure Enclave key by its label.
+///
+/// Returns `Ok(())` if the key was deleted or was already absent.
+/// Returns `Err` if the keychain search or deletion fails for other reasons.
+pub fn delete(label: &str) -> Result<(), TempoError> {
+    let key = match load(label) {
+        Ok(k) => k,
+        Err(TempoError::Key(KeyError::Keychain(msg))) if msg.contains("not found") => return Ok(()),
+        Err(e) => return Err(e),
+    };
+    key.delete()
+        .map_err(|e| KeyError::Keychain(format!("Failed to delete SE key: {e}")).into())
+}
+
+/// Extract the uncompressed public key bytes from a Secure Enclave key.
+///
+/// Returns 65 bytes: `04 || X (32 bytes) || Y (32 bytes)`.
+fn extract_public_key_bytes(key: &SecKey) -> Result<Vec<u8>, TempoError> {
+    let public = key
+        .public_key()
+        .ok_or_else(|| KeyError::Keychain("SE key has no public key".to_string()))?;
+
+    let data = public
+        .external_representation()
+        .ok_or_else(|| KeyError::Keychain("Failed to export SE public key".to_string()))?;
+
+    Ok(data.to_vec())
+}
+
+// ---------------------------------------------------------------------------
+// DER signature parsing and normalization
+// ---------------------------------------------------------------------------
+
+/// Parse a DER-encoded ECDSA signature into (r, s) as 32-byte big-endian arrays.
+///
+/// The DER format is: SEQUENCE { INTEGER r, INTEGER s }.
+/// Integers may have a leading zero byte for sign padding which we strip.
+pub fn parse_der_signature(der: &[u8]) -> Result<([u8; 32], [u8; 32]), TempoError> {
+    if der.len() < 8 || der[0] != 0x30 {
+        return Err(KeyError::Signing("Invalid DER signature: bad header".to_string()).into());
+    }
+
+    let (r_bytes, rest) = read_der_integer(&der[2..])?;
+    let (s_bytes, _) = read_der_integer(rest)?;
+
+    Ok((pad_to_32(r_bytes)?, pad_to_32(s_bytes)?))
+}
+
+/// Normalize the S value of an ECDSA signature to the lower half of the curve order.
+///
+/// P256 curve order N. If s > N/2, replace s with N - s.
+/// This is required for Ethereum-compatible signature verification.
+pub fn normalize_s(s: [u8; 32]) -> [u8; 32] {
+    // P256 curve order N
+    const N: [u8; 32] = [
+        0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xBC, 0xE6, 0xFA, 0xAD, 0xA7, 0x17, 0x9E, 0x84, 0xF3, 0xB9, 0xCA, 0xC2, 0xFC, 0x63,
+        0x25, 0x51,
+    ];
+    // N/2 (precomputed)
+    const HALF_N: [u8; 32] = [
+        0x7F, 0xFF, 0xFF, 0xFF, 0x80, 0x00, 0x00, 0x00, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xDE, 0x73, 0x7D, 0x56, 0xD3, 0x8B, 0xCF, 0x42, 0x79, 0xDC, 0xE5, 0x61, 0x7E, 0x31,
+        0x92, 0xA8,
+    ];
+
+    if !gt_be(&s, &HALF_N) {
+        return s;
+    }
+
+    // s = N - s (big-endian subtraction)
+    let mut result = [0u8; 32];
+    let mut borrow: u16 = 0;
+    for i in (0..32).rev() {
+        let diff = (N[i] as u16).wrapping_sub(s[i] as u16).wrapping_sub(borrow);
+        result[i] = diff as u8;
+        borrow = if diff > 0xFF { 1 } else { 0 };
+    }
+    result
+}
+
+/// Derive an Ethereum address from an uncompressed P256 public key (65 bytes).
+///
+/// Strips the 0x04 prefix, Keccak-256 hashes the 64-byte X||Y,
+/// and takes the last 20 bytes.
+pub fn address_from_pubkey(uncompressed: &[u8]) -> Result<[u8; 20], TempoError> {
+    if uncompressed.len() != 65 || uncompressed[0] != 0x04 {
+        return Err(KeyError::InvalidKey(
+            "Expected 65-byte uncompressed P256 public key".to_string(),
+        )
+        .into());
+    }
+
+    use alloy::primitives::keccak256;
+    let hash = keccak256(&uncompressed[1..]);
+    let mut addr = [0u8; 20];
+    addr.copy_from_slice(&hash[12..]);
+    Ok(addr)
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Read a DER INTEGER and return (value_bytes, remaining_slice).
+fn read_der_integer(data: &[u8]) -> Result<(&[u8], &[u8]), TempoError> {
+    if data.len() < 2 || data[0] != 0x02 {
+        return Err(KeyError::Signing("Invalid DER integer tag".to_string()).into());
+    }
+    let len = data[1] as usize;
+    if data.len() < 2 + len {
+        return Err(KeyError::Signing("DER integer length overflow".to_string()).into());
+    }
+    let value = &data[2..2 + len];
+    let rest = &data[2 + len..];
+    // Strip leading zero used for sign padding
+    let value = if value.len() > 1 && value[0] == 0x00 {
+        &value[1..]
+    } else {
+        value
+    };
+    Ok((value, rest))
+}
+
+/// Left-pad a byte slice to exactly 32 bytes.
+fn pad_to_32(bytes: &[u8]) -> Result<[u8; 32], TempoError> {
+    if bytes.len() > 32 {
+        return Err(KeyError::Signing("DER integer too large for P256".to_string()).into());
+    }
+    let mut out = [0u8; 32];
+    out[32 - bytes.len()..].copy_from_slice(bytes);
+    Ok(out)
+}
+
+/// Compare two 32-byte big-endian values: a > b.
+fn gt_be(a: &[u8; 32], b: &[u8; 32]) -> bool {
+    for i in 0..32 {
+        if a[i] > b[i] {
+            return true;
+        }
+        if a[i] < b[i] {
+            return false;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_key_label() {
+        assert_eq!(key_label("0xAbCd"), "xyz.tempo.wallet.se.0xAbCd");
+    }
+
+    #[test]
+    fn test_parse_der_signature_valid() {
+        // A minimal valid DER ECDSA signature (r=1, s=1)
+        let der = vec![
+            0x30, 0x06, // SEQUENCE, length 6
+            0x02, 0x01, 0x01, // INTEGER, length 1, value 1
+            0x02, 0x01, 0x01, // INTEGER, length 1, value 1
+        ];
+        let (r, s) = parse_der_signature(&der).unwrap();
+        assert_eq!(r[31], 1);
+        assert_eq!(s[31], 1);
+        assert!(r[..31].iter().all(|&b| b == 0));
+        assert!(s[..31].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn test_parse_der_strips_leading_zero() {
+        // r with leading zero padding (33 bytes encoded, 32 bytes actual)
+        let der = vec![
+            0x30, 0x07, 0x02, 0x02, 0x00,
+            0xFF, // INTEGER with leading zero, actual value 0xFF
+            0x02, 0x01, 0x01, // INTEGER, value 1
+        ];
+        let (r, _) = parse_der_signature(&der).unwrap();
+        assert_eq!(r[31], 0xFF);
+        assert!(r[..31].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn test_parse_der_invalid_header() {
+        assert!(parse_der_signature(&[0x31, 0x00]).is_err());
+    }
+
+    #[test]
+    fn test_parse_der_too_short() {
+        assert!(parse_der_signature(&[0x30]).is_err());
+    }
+
+    #[test]
+    fn test_normalize_s_low_unchanged() {
+        let mut s = [0u8; 32];
+        s[31] = 1;
+        assert_eq!(normalize_s(s), s);
+    }
+
+    #[test]
+    fn test_normalize_s_high_flipped() {
+        // s = N - 1 (which is > N/2), should become 1
+        // N = FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551
+        // N - 1 last byte is 0x50
+        let n_minus_1: [u8; 32] = [
+            0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xBC, 0xE6, 0xFA, 0xAD, 0xA7, 0x17, 0x9E, 0x84, 0xF3, 0xB9, 0xCA, 0xC2,
+            0xFC, 0x63, 0x25, 0x50,
+        ];
+        let result = normalize_s(n_minus_1);
+        let mut expected = [0u8; 32];
+        expected[31] = 1;
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_normalize_s_half_n_unchanged() {
+        // s = N/2 exactly — should NOT be flipped
+        let half_n: [u8; 32] = [
+            0x7F, 0xFF, 0xFF, 0xFF, 0x80, 0x00, 0x00, 0x00, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xDE, 0x73, 0x7D, 0x56, 0xD3, 0x8B, 0xCF, 0x42, 0x79, 0xDC, 0xE5, 0x61,
+            0x7E, 0x31, 0x92, 0xA8,
+        ];
+        assert_eq!(normalize_s(half_n), half_n);
+    }
+
+    #[test]
+    fn test_address_from_pubkey_valid() {
+        // Known test vector: uncompressed pubkey from a P256 key
+        // We just verify it produces a 20-byte address without error
+        let mut pubkey = vec![0x04];
+        pubkey.extend_from_slice(&[0xAA; 32]); // X
+        pubkey.extend_from_slice(&[0xBB; 32]); // Y
+        let addr = address_from_pubkey(&pubkey).unwrap();
+        assert_eq!(addr.len(), 20);
+    }
+
+    #[test]
+    fn test_address_from_pubkey_wrong_prefix() {
+        let mut pubkey = vec![0x02]; // compressed, not uncompressed
+        pubkey.extend_from_slice(&[0x00; 64]);
+        assert!(address_from_pubkey(&pubkey).is_err());
+    }
+
+    #[test]
+    fn test_address_from_pubkey_wrong_length() {
+        let pubkey = vec![0x04, 0x00]; // too short
+        assert!(address_from_pubkey(&pubkey).is_err());
+    }
+
+    /// Requires physical macOS with Secure Enclave (T2/Apple Silicon) and
+    /// a binary signed with an Apple Developer identity. Ad-hoc signing
+    /// is not sufficient for Data Protection Keychain access.
+    ///
+    /// To run: build the test binary, codesign with a Developer ID, then
+    /// run directly: `./target/debug/deps/tempo_common-* --ignored test_se_generate_load_sign_delete`
+    #[test]
+    #[ignore]
+    fn test_se_generate_load_sign_delete() {
+        let label = key_label("integration-test");
+        // Clean up from previous runs
+        let _ = delete(&label);
+
+        // Generate
+        let pubkey = generate(&label).unwrap();
+        assert_eq!(pubkey.len(), 65);
+        assert_eq!(pubkey[0], 0x04);
+
+        // Load
+        let key = load(&label).unwrap();
+
+        // Sign a test digest
+        let digest = [0xAB_u8; 32];
+        let sig = sign(&key, &digest).unwrap();
+        assert!(!sig.is_empty());
+
+        // Parse DER
+        let (r, s) = parse_der_signature(&sig).unwrap();
+        assert!(r.iter().any(|&b| b != 0));
+        assert!(s.iter().any(|&b| b != 0));
+
+        // Derive address
+        let addr = address_from_pubkey(&pubkey).unwrap();
+        assert_eq!(addr.len(), 20);
+
+        // Delete
+        delete(&label).unwrap();
+        assert!(load(&label).is_err());
+    }
+}

--- a/crates/tempo-common/src/keys/signer.rs
+++ b/crates/tempo-common/src/keys/signer.rs
@@ -12,6 +12,7 @@ use crate::error::{ConfigError, KeyError, TempoError};
 use crate::network::NetworkId;
 
 use super::authorization;
+use super::model::WalletType;
 use super::Keystore;
 
 /// Parse a private key hex string into a PrivateKeySigner.
@@ -30,10 +31,16 @@ pub fn parse_private_key_signer(pk_str: &str) -> Result<PrivateKeySigner, TempoE
 ///
 /// Bundles the private key signer, the resolved `TempoSigningMode`
 /// (direct or keychain), and the effective `from` address.
+///
+/// For Secure Enclave wallets, `se_key_label` is set and the `signer`
+/// field is a dummy — all actual signing goes through the SE hardware.
 pub struct Signer {
     pub signer: PrivateKeySigner,
     pub signing_mode: TempoSigningMode,
     pub from: Address,
+    /// When set, this signer is backed by a macOS Secure Enclave key.
+    /// The `signer` field is a placeholder; use the SE label for signing.
+    pub se_key_label: Option<String>,
 }
 
 impl Keystore {
@@ -49,6 +56,11 @@ impl Keystore {
                 network.as_str()
             )))
         })?;
+
+        // Secure Enclave wallets: no inline private key, use SE label.
+        if key_entry.wallet_type == WalletType::SecureEnclave {
+            return self.signer_se(key_entry, network);
+        }
 
         let pk = key_entry
             .key
@@ -93,6 +105,74 @@ impl Keystore {
             signer,
             signing_mode,
             from,
+            se_key_label: None,
+        })
+    }
+
+    /// Build a [`Signer`] for a Secure Enclave key entry.
+    ///
+    /// The `signer` field is a dummy `PrivateKeySigner` (random, never used
+    /// for actual signing). The `se_key_label` field carries the SE label.
+    /// Callers must check `se_key_label` before using `signer` directly.
+    fn signer_se(
+        &self,
+        key_entry: &super::KeyEntry,
+        network: NetworkId,
+    ) -> Result<Signer, TempoError> {
+        let se_label = key_entry.se_key_label.as_deref().ok_or_else(|| {
+            TempoError::from(ConfigError::Missing(
+                "Secure Enclave key entry missing se_key_label.".to_string(),
+            ))
+        })?;
+
+        let wallet_address: Address = key_entry.wallet_address.parse().map_err(|e| {
+            TempoError::from(ConfigError::Invalid(format!(
+                "Invalid wallet address: {}",
+                e
+            )))
+        })?;
+
+        let key_address: Address = key_entry
+            .key_address
+            .as_deref()
+            .ok_or_else(|| {
+                TempoError::from(ConfigError::Missing(
+                    "Secure Enclave key entry missing key_address.".to_string(),
+                ))
+            })?
+            .parse()
+            .map_err(|e| {
+                TempoError::from(ConfigError::Invalid(format!("Invalid key address: {}", e)))
+            })?;
+
+        let local_auth = key_entry
+            .key_authorization
+            .as_deref()
+            .and_then(authorization::decode);
+
+        let key_authorization = if !self.is_provisioned(network) {
+            local_auth.map(Box::new)
+        } else {
+            None
+        };
+
+        let signing_mode = TempoSigningMode::Keychain {
+            wallet: wallet_address,
+            key_authorization,
+            version: KeychainVersion::V1,
+        };
+
+        let from = signing_mode.from_address(key_address);
+
+        // Dummy signer — SE keys never expose private key material.
+        // Callers must use `se_key_label` for actual signing operations.
+        let dummy = PrivateKeySigner::random();
+
+        Ok(Signer {
+            signer: dummy,
+            signing_mode,
+            from,
+            se_key_label: Some(se_label.to_string()),
         })
     }
 }

--- a/crates/tempo-request/src/payment/charge.rs
+++ b/crates/tempo-request/src/payment/charge.rs
@@ -26,6 +26,10 @@ pub(super) async fn handle_charge_request(
 ) -> Result<PaymentResult> {
     let challenge = &resolved.challenge;
 
+    if signer.se_key_label.is_some() {
+        anyhow::bail!("Charge payments are not yet supported with Secure Enclave wallets. Use a passkey or local wallet.");
+    }
+
     challenge
         .validate_for_charge("tempo")
         .map_err(|e| map_mpp_validation_error(e, challenge))?;

--- a/crates/tempo-request/src/payment/session/flow.rs
+++ b/crates/tempo-request/src/payment/session/flow.rs
@@ -112,6 +112,10 @@ pub(crate) async fn handle_session_request(
     let network_id = resolved.network_id;
     let network_name = network_id.as_str();
 
+    if signer.se_key_label.is_some() {
+        anyhow::bail!("Session payments are not yet supported with Secure Enclave wallets. Use a passkey or local wallet.");
+    }
+
     challenge
         .validate_for_session("tempo")
         .map_err(|e| map_mpp_validation_error(e, challenge))?;

--- a/crates/tempo-wallet/src/app.rs
+++ b/crates/tempo-wallet/src/app.rs
@@ -21,7 +21,7 @@ pub(crate) async fn run(mut cli: Cli) -> Result<()> {
         let cmd_name = command_name(&command);
         tempo_common::cli::tracking::track_command(&ctx.analytics, cmd_name);
         let result = match command {
-            Commands::Login => login::run(&ctx).await,
+            Commands::Login { secure_enclave } => login::run(&ctx, secure_enclave).await,
             Commands::Logout { yes } => logout::run(&ctx, yes),
             Commands::Completions { shell } => completions::run(&ctx, shell),
             Commands::List => wallets::list(&ctx),
@@ -69,7 +69,7 @@ pub(crate) async fn run(mut cli: Cli) -> Result<()> {
 /// Derive a short analytics-friendly name from a parsed command.
 fn command_name(command: &Commands) -> &'static str {
     match command {
-        Commands::Login => "login",
+        Commands::Login { .. } => "login",
         Commands::Logout { .. } => "logout",
         Commands::Completions { .. } => "completions",
         Commands::List => "list",

--- a/crates/tempo-wallet/src/args.rs
+++ b/crates/tempo-wallet/src/args.rs
@@ -40,7 +40,11 @@ pub(crate) struct Cli {
 pub(crate) enum Commands {
     /// Sign up or log in to your Tempo wallet
     #[command(display_order = 1)]
-    Login,
+    Login {
+        /// Create a Secure Enclave wallet (macOS only, requires Touch ID)
+        #[arg(long)]
+        secure_enclave: bool,
+    },
     /// Log out and disconnect your wallet
     #[command(display_order = 2)]
     Logout {

--- a/crates/tempo-wallet/src/commands/login.rs
+++ b/crates/tempo-wallet/src/commands/login.rs
@@ -24,7 +24,14 @@ use tempo_common::security::sanitize_error;
 const CALLBACK_TIMEOUT_SECS: u64 = 900; // 15 minutes
 const POLL_INTERVAL_SECS: u64 = 2;
 
-pub(crate) async fn run(ctx: &Context) -> anyhow::Result<()> {
+pub(crate) async fn run(ctx: &Context, secure_enclave: bool) -> anyhow::Result<()> {
+    if secure_enclave {
+        #[cfg(target_os = "macos")]
+        return se_login(ctx).await;
+        #[cfg(not(target_os = "macos"))]
+        anyhow::bail!("Secure Enclave wallets are only supported on macOS.");
+    }
+
     ctx.track_event(analytics::LOGIN_STARTED);
 
     let already_logged_in = ctx.keys.has_key_for_network(ctx.network);
@@ -355,6 +362,79 @@ async fn poll_device_code(
             e
         )))
     })
+}
+
+// ---------------------------------------------------------------------------
+// Secure Enclave login
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "macos")]
+async fn se_login(ctx: &Context) -> anyhow::Result<()> {
+    use tempo_common::cli::output::OutputFormat;
+    use tempo_common::keys::secure_enclave;
+
+    // Check if already logged in with an SE wallet on this network.
+    let has_se_for_network = ctx
+        .keys
+        .find_se_wallet()
+        .is_some_and(|entry| entry.chain_id == ctx.network.chain_id());
+    if has_se_for_network {
+        if ctx.output_format == OutputFormat::Text {
+            eprintln!("Already logged in with Secure Enclave wallet.\n");
+        }
+        let keys = ctx.keys.reload()?;
+        return super::whoami::show_whoami(ctx, Some(&keys), None).await;
+    }
+
+    if ctx.output_format == OutputFormat::Text {
+        eprintln!("Generating Secure Enclave key (Touch ID required)...");
+    }
+
+    // Generate SE key — label is deterministic from a random suffix.
+    // We use a short random suffix to allow multiple SE wallets.
+    let mut suffix_bytes = [0u8; 8];
+    getrandom::getrandom(&mut suffix_bytes).expect("failed to generate random bytes");
+    let suffix = hex::encode(suffix_bytes);
+    let label = secure_enclave::key_label(&suffix);
+
+    let pubkey = secure_enclave::generate(&label)?;
+    let addr_bytes = secure_enclave::address_from_pubkey(&pubkey)?;
+    let key_address = format!("0x{}", hex::encode(addr_bytes));
+
+    if ctx.output_format == OutputFormat::Text {
+        eprintln!("Key address: {}", key_address);
+    }
+
+    // For SE wallets, the wallet_address IS the key_address (direct EOA).
+    // No separate wallet owner key — the SE key is the identity.
+    let wallet_address = key_address.clone();
+    let chain_id = ctx.network.chain_id();
+
+    let mut keys = ctx.keys.clone();
+    let entry = keys.upsert_by_wallet_and_chain(&wallet_address, chain_id);
+    entry.wallet_type = WalletType::SecureEnclave;
+    entry.wallet_address = wallet_address.clone();
+    entry.key_type = tempo_common::keys::KeyType::P256;
+    entry.key_address = Some(key_address);
+    entry.se_key_label = Some(label);
+    entry.key = None;
+    entry.provisioned = false;
+
+    keys.save()?;
+
+    ctx.track(
+        analytics::WALLET_CREATED,
+        WalletCreatedPayload {
+            wallet_type: "secure_enclave".to_string(),
+        },
+    );
+
+    if ctx.output_format == OutputFormat::Text {
+        eprintln!("\nSecure Enclave wallet created!\n");
+    }
+
+    let keys = keys.reload()?;
+    super::whoami::show_whoami(ctx, Some(&keys), Some(&wallet_address)).await
 }
 
 fn generate_pkce_pair() -> (String, String) {

--- a/crates/tempo-wallet/src/commands/logout.rs
+++ b/crates/tempo-wallet/src/commands/logout.rs
@@ -15,7 +15,12 @@ struct LogoutResponse {
 }
 
 pub(crate) fn run(ctx: &Context, yes: bool) -> anyhow::Result<()> {
-    let wallet_addr = match ctx.keys.find_passkey_wallet() {
+    // Try SE wallet first (higher priority), then passkey
+    let wallet_addr = match ctx
+        .keys
+        .find_se_wallet()
+        .or_else(|| ctx.keys.find_passkey_wallet())
+    {
         Some(entry) => entry.wallet_address.clone(),
         None => {
             output::emit_by_format(
@@ -62,7 +67,15 @@ pub(crate) fn run(ctx: &Context, yes: bool) -> anyhow::Result<()> {
     }
 
     let mut keys = ctx.keys.clone();
-    keys.delete_passkey_wallet(&wallet_addr)?;
+    // SE keys are NOT deleted from hardware on logout — only disconnected
+    // from keys.toml. The key persists in the Secure Enclave and can be
+    // re-associated later. Use `keys clean` to permanently destroy SE keys.
+    //
+    // Try SE wallet first, fall back to passkey
+    let delete_result = keys
+        .delete_se_wallet(&wallet_addr)
+        .or_else(|_| keys.delete_passkey_wallet(&wallet_addr));
+    delete_result?;
     keys.save()?;
 
     ctx.track_event(LOGOUT);

--- a/crates/tempo-wallet/src/commands/sign.rs
+++ b/crates/tempo-wallet/src/commands/sign.rs
@@ -60,6 +60,9 @@ pub(crate) async fn run(ctx: &Context, challenge_arg: Option<String>, dry_run: b
 
     // Sign
     let signer = ctx.keys.signer(network)?;
+    if signer.se_key_label.is_some() {
+        anyhow::bail!("Sign command is not yet supported with Secure Enclave wallets.");
+    }
     let from = signer.from;
     let rpc_url = ctx.config.rpc_url(network);
 

--- a/crates/tempo-wallet/src/commands/wallets/create.rs
+++ b/crates/tempo-wallet/src/commands/wallets/create.rs
@@ -48,6 +48,7 @@ pub(super) fn create_local_wallet(network: &NetworkId, keys: &Keystore) -> Resul
         wallet_address: wallet_address.clone(),
         key_address: Some(access_key_address),
         key: Some(access_key_hex),
+        se_key_label: None,
         key_authorization: Some(auth.hex),
         chain_id,
         key_type: auth.key_type,


### PR DESCRIPTION
![Secure Enclave user flow](https://iili.io/q5rJ5HN.png)

Store P256 signing keys in the Secure Enclave. Keys never leave the hardware — signing requires Touch ID on every operation.

## What this adds

`tempo wallet login --secure-enclave` generates a P256 key in the Secure Enclave, derives an Ethereum address from it, and saves the key label (not the key) to `keys.toml`. Logout disconnects the wallet from config but leaves the SE key in hardware — destroying a non-recoverable key on disconnect would mean permanent fund loss.

The signing pipeline (`secure_enclave.rs`) handles the full lifecycle: generate, load, sign, delete. It parses DER signatures, normalizes S to the lower half of the P256 curve order (required for Ethereum), and derives addresses via Keccak-256.

Charge and session payments bail with a clear message — SE signing integration with the MPP payment flow is a follow-up.

## CI: codesign + notarize macOS binaries

The Data Protection Keychain rejects unsigned binaries (`errSecMissingEntitlement`). The release workflow now signs macOS builds with a Developer ID Application certificate and submits them to Apple for notarization. The `curl|sh` installer downloads the pre-signed binary — SE access works out of the box.

Both CI steps are gated on secrets being present, so builds still work without them.

## Steps to activate

This PR is code-complete. To make SE wallets work end-to-end:

1. **Enroll in the Apple Developer Program** ($99/yr) at https://developer.apple.com/programs/
2. **Create a Developer ID Application certificate** in the Apple Developer portal (Certificates, Identifiers & Profiles)
3. **Export the certificate as a `.p12` file** from Keychain Access, base64-encode it
4. **Create an App Store Connect API key** at https://appstoreconnect.apple.com/access/integrations/api
5. **Add 5 GitHub secrets** to the repo:

| Secret | Value |
|--------|-------|
| `APPLE_CERT_P12` | Base64-encoded `.p12` (Developer ID Application cert + private key) |
| `APPLE_CERT_PASSWORD` | Password for the `.p12` |
| `APPLE_API_KEY_ID` | App Store Connect API key ID |
| `APPLE_API_KEY_DATA` | Contents of the `.p8` API key file |
| `APPLE_API_ISSUER` | Issuer UUID from App Store Connect |

6. **Update the signing identity** in `release.yml` to match your cert name
7. **Update the team ID** in `assets/entitlements.plist` if needed

Once secrets are in place, the next push to `main` produces signed+notarized macOS binaries with SE access.