### PR TITLE
fix(sessions): try cooperative close when closing by channel ID

### DIFF
--- a/crates/tempo-common/src/payment/session/mod.rs
+++ b/crates/tempo-common/src/payment/session/mod.rs
@@ -23,7 +23,7 @@ pub const DEFAULT_GRACE_PERIOD_SECS: u64 = 900;
 // Re-export public API from `store`
 pub use store::{
     acquire_origin_lock, delete_session, delete_session_by_channel_id, list_sessions, load_session,
-    now_secs, save_session, session_key, take_store_diagnostics,
+    load_session_by_channel_id, now_secs, save_session, session_key, take_store_diagnostics,
     update_session_close_state_by_channel_id, SessionLock, SessionRecord, SessionStatus,
     SessionStoreDiagnostics,
 };

--- a/crates/tempo-common/src/payment/session/store/mod.rs
+++ b/crates/tempo-common/src/payment/session/store/mod.rs
@@ -7,6 +7,7 @@ mod storage;
 pub use lock::{acquire_origin_lock, SessionLock};
 pub use model::{now_secs, session_key, SessionRecord, SessionStatus};
 pub use storage::{
-    delete_session, delete_session_by_channel_id, list_sessions, load_session, save_session,
-    take_store_diagnostics, update_session_close_state_by_channel_id, SessionStoreDiagnostics,
+    delete_session, delete_session_by_channel_id, list_sessions, load_session,
+    load_session_by_channel_id, save_session, take_store_diagnostics,
+    update_session_close_state_by_channel_id, SessionStoreDiagnostics,
 };

--- a/crates/tempo-common/src/payment/session/store/storage.rs
+++ b/crates/tempo-common/src/payment/session/store/storage.rs
@@ -335,6 +335,39 @@ fn delete_session_conn(conn: &rusqlite::Connection, key: &str) -> SessionStoreRe
     Ok(())
 }
 
+fn load_session_by_channel_id_conn(
+    conn: &rusqlite::Connection,
+    channel_id: B256,
+) -> SessionStoreResult<Option<SessionRecord>> {
+    let channel_id = format!("{channel_id:#x}");
+    let mut stmt = conn
+        .prepare(
+            "SELECT version, origin, request_url, chain_id,
+                    escrow_contract, currency, recipient, payer, authorized_signer,
+                    salt, channel_id, deposit, tick_cost, cumulative_amount,
+                    challenge_echo, state, close_requested_at, grace_ready_at, created_at, last_used_at
+             FROM sessions WHERE LOWER(channel_id) = ?1",
+        )
+        .map_err(|err| store_error("prepare session load by channel id query", err))?;
+
+    let result = stmt.query_row(params![channel_id], map_session_row);
+
+    match result {
+        Ok(record) => Ok(Some(record)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) if is_malformed_session_row_error(&e) => {
+            MALFORMED_LOAD_DROPS.fetch_add(1, Ordering::Relaxed);
+            tracing::warn!(
+                %channel_id,
+                error = %e,
+                "Skipping malformed session row while loading by channel ID"
+            );
+            Ok(None)
+        }
+        Err(e) => Err(store_error("load session by channel id", e)),
+    }
+}
+
 fn delete_session_by_channel_id_conn(
     conn: &rusqlite::Connection,
     channel_id: B256,
@@ -420,6 +453,16 @@ pub fn save_session(record: &SessionRecord) -> SessionStoreResult<()> {
 pub fn delete_session(key: &str) -> SessionStoreResult<()> {
     let conn = open_db()?;
     delete_session_conn(&conn, key)
+}
+
+/// Load a session record by channel ID. Returns `None` if not found.
+///
+/// # Errors
+///
+/// Returns an error when the database cannot be opened or SQL fails.
+pub fn load_session_by_channel_id(channel_id: B256) -> SessionStoreResult<Option<SessionRecord>> {
+    let conn = open_db()?;
+    load_session_by_channel_id_conn(&conn, channel_id)
 }
 
 /// Delete a session record by channel ID.

--- a/crates/tempo-wallet/src/commands/sessions/close.rs
+++ b/crates/tempo-wallet/src/commands/sessions/close.rs
@@ -219,7 +219,43 @@ async fn close_all_sessions(ctx: &Context) -> Result<(), TempoError> {
 }
 
 /// Close a single channel by its on-chain ID (0x...).
+///
+/// If a local session record exists for this channel, routes through
+/// `close_session_from_record` which tries cooperative close first.
+/// Falls back to on-chain-only close when no local record is found.
 async fn close_by_channel_id(ctx: &Context, target: &str) -> Result<(), TempoError> {
+    let channel_id = super::util::parse_channel_id(target)?;
+
+    // Try local session record first — enables cooperative close
+    if let Ok(Some(record)) = session_store::load_session_by_channel_id(channel_id) {
+        if record.network_id() == ctx.network {
+            let show_output = ctx.verbosity.show_output;
+            let analytics = ctx.analytics.as_ref();
+            let key = session_store::session_key(&record.origin);
+            let mut summary = CloseSummary::new();
+
+            let result =
+                close_session_from_record(&record, &ctx.config, analytics, &ctx.keys).await;
+            if matches!(result, Ok(CloseOutcome::Closed { .. })) {
+                if let Err(e) = session_store::delete_session(&key) {
+                    if show_output {
+                        eprintln!("  Failed to remove local session: {e}");
+                    }
+                }
+            }
+            let cid = record.channel_id_hex();
+            summary.record_outcome(
+                result,
+                Some(&record.origin),
+                &record.origin,
+                &cid,
+                show_output,
+            );
+            return summary.print(ctx.output_format, "No channel to close.", "closed");
+        }
+    }
+
+    // No local record (orphaned channel) — on-chain close only
     let mut summary = CloseSummary::new();
     let result = close_channel_by_id(&ctx.config, target, ctx.network, None, &ctx.keys).await;
     summary.record_finalize_outcome(result, target, true);


### PR DESCRIPTION
## Summary

`sessions close 0x...` now tries cooperative close first (instant settlement) instead of always using the slow 15-min unilateral on-chain path.

## Motivation

Closing by channel ID (the natural thing to copy from `sessions list` output) routed directly to `close_channel_by_id` which only does on-chain `requestClose → 15min grace → withdraw`. Closing by URL correctly went through `close_session_from_record` which tries cooperative close first. This asymmetry meant users who close by channel ID always got the slow path even when instant close would succeed.

## Changes

- Added `load_session_by_channel_id` to session store (`tempo-common`)
- `close_by_channel_id` now looks up the local session record first; if found and on the same network, routes through `close_session_from_record` (cooperative → on-chain fallback)
- Falls through to on-chain-only close for truly orphaned channels with no local record

## Testing

`make check` passes (fmt, clippy, tests, docs).

Co-Authored-By: Daniel Robinson <1187252+danrobinson@users.noreply.github.com>

Prompted by: dan