### PR TITLE
fix: preserve OSC 8 hyperlinks in terminal output

### DIFF
--- a/crates/tempo-common/src/cli/terminal.rs
+++ b/crates/tempo-common/src/cli/terminal.rs
@@ -111,6 +111,9 @@ pub fn truncate(s: &str, max: usize) -> String {
 }
 
 /// Print a right-aligned label/value field to stdout with a custom label width.
+///
+/// The value is sanitized to strip control characters. For pre-formatted values
+/// (e.g. containing OSC 8 hyperlinks), use [`print_field_raw_w`] instead.
 pub fn print_field_w(width: usize, label: &str, value: &str) {
     let safe_value = sanitize_for_terminal(value);
     println!("{label:>width$}: {safe_value}");
@@ -119,6 +122,17 @@ pub fn print_field_w(width: usize, label: &str, value: &str) {
 /// Print a right-aligned label/value field to stdout (14-char label width).
 pub fn print_field(label: &str, value: &str) {
     print_field_w(14, label, value);
+}
+
+/// Like [`print_field_w`] but skips sanitization — use for values that already
+/// contain intentional terminal sequences (e.g. OSC 8 hyperlinks from [`hyperlink`]).
+pub fn print_field_raw_w(width: usize, label: &str, value: &str) {
+    println!("{label:>width$}: {value}");
+}
+
+/// Like [`print_field`] but skips sanitization.
+pub fn print_field_raw(label: &str, value: &str) {
+    print_field_raw_w(14, label, value);
 }
 
 #[cfg(test)]
@@ -197,5 +211,26 @@ mod tests {
     #[test]
     fn truncate_long_adds_ellipsis() {
         assert_eq!(truncate("hello world", 5), "hell…");
+    }
+
+    #[test]
+    fn print_field_raw_preserves_osc8_hyperlinks() {
+        // Simulate what hyperlink() produces when the terminal supports OSC 8.
+        let osc8 = "\x1b]8;;https://example.com/address/0xabc\x070xabc\x1b]8;;\x07";
+
+        // print_field_raw_w uses the same format! — verify it preserves
+        // the ESC (\x1b) and BEL (\x07) bytes that OSC 8 requires.
+        let formatted = format!("{:>10}: {osc8}", "Wallet");
+        assert!(
+            formatted.contains('\x1b') && formatted.contains('\x07'),
+            "print_field_raw_w must preserve intentional OSC 8 sequences"
+        );
+
+        // Whereas print_field_w would strip them (the original bug).
+        let sanitized = format!("{:>10}: {}", "Wallet", sanitize_for_terminal(osc8));
+        assert!(
+            !sanitized.contains('\x1b') && !sanitized.contains('\x07'),
+            "print_field_w must sanitize control characters"
+        );
     }
 }

--- a/crates/tempo-wallet/src/commands/keys.rs
+++ b/crates/tempo-wallet/src/commands/keys.rs
@@ -12,7 +12,7 @@ use tempo_common::{
     cli::{
         context::Context,
         output,
-        terminal::{address_link, print_field_w},
+        terminal::{address_link, print_field_raw_w, print_field_w},
     },
     error::TempoError,
     keys::Keystore,
@@ -86,7 +86,7 @@ fn render_keys(response: &KeysResponse, keystore: &Keystore, sessions: &[session
 
         if let Some(wallet) = &key.wallet_address {
             let wallet_link = address_link(explorer.unwrap_or_default(), wallet);
-            print_field_w(10, "Wallet", &wallet_link);
+            print_field_raw_w(10, "Wallet", &wallet_link);
         }
         if let (Some(bal), Some(sym)) = (key.balance.as_deref(), key.symbol.as_deref()) {
             if let Some(bb) = balance_breakdown(bal, sym, Some(entry.chain_id), sessions) {
@@ -113,7 +113,7 @@ fn render_keys(response: &KeysResponse, keystore: &Keystore, sessions: &[session
             print_field_w(10, "Key", pk.as_str());
         } else {
             let key_link = address_link(explorer.unwrap_or_default(), &key.address);
-            print_field_w(10, "Key", &key_link);
+            print_field_raw_w(10, "Key", &key_link);
         }
         if let Some(net) = explorer {
             print_field_w(10, "Chain", net.as_str());


### PR DESCRIPTION
`print_field_w` sanitizes values to strip control characters, which also strips the ESC and BEL bytes that OSC 8 hyperlinks need. This caused `address_link` output in `wallet keys` (and anywhere else hyperlinks pass through `print_field_w`) to render as raw `]8;;url addr]8;;` instead of a clickable link.

Before:
```
    Wallet: ]8;;https://explore.mainnet.tempo.xyz/address/0x...0x...]8;;
   Balance: X.XXXXXX USDC
       Key: 0x...
     Chain: tempo
   Expires: XXd XXh
     Limit: X.XXXXXX / X.XXXXXX USDC (X.XXXXXX remaining)
```

Added `print_field_raw_w`/`print_field_raw` variants that skip sanitization for pre-formatted values like `hyperlink()` output, and switched the two call sites in `keys.rs` that pass `address_link` results.