### PR TITLE
fix(ci): pass inherited secrets to pr-audit reusable workflow

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -9,3 +9,4 @@ on:
 jobs:
   pr-audit:
     uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- add `secrets: inherit` to `.github/workflows/pr-audit.yml`
- ensure required secrets for `tempoxyz/gh-actions/.github/workflows/pr-audit.yml@main` are forwarded by the caller

## Why
The PR Audit workflow was failing at startup (no jobs created) because the called reusable workflow requires `EVENTS_KEY`, `EVENTS_CERT`, and `EVENTS_ARGS` secrets, but the caller did not pass any secrets.
