### PR TITLE
feat: auto-enable TOON output when running inside LLM agents

### DIFF
--- a/crates/tempo-common/src/cli/args.rs
+++ b/crates/tempo-common/src/cli/args.rs
@@ -96,15 +96,17 @@ pub struct GlobalArgs {
 impl GlobalArgs {
     /// Resolve the effective output format from CLI flags.
     ///
-    /// When neither `--json-output` nor `--toon-output` is explicitly set and
-    /// stdout is not a terminal, defaults to JSON for machine-friendly output.
+    /// When neither `--json-output` nor `--toon-output` is explicitly set:
+    /// - If running inside an LLM agent (detected via env vars), defaults to TOON.
+    /// - Otherwise, if stdout is not a terminal, defaults to JSON.
+    ///
     /// Set `TEMPO_NO_AUTO_JSON=1` to disable auto-detection.
     #[must_use]
     pub fn resolve_output_format(&self) -> OutputFormat {
         use std::io::IsTerminal;
         if self.json_output {
             OutputFormat::Json
-        } else if self.toon_output {
+        } else if self.toon_output || is_agent_environment() {
             OutputFormat::Toon
         } else if should_auto_json() && !std::io::stdout().is_terminal() {
             OutputFormat::Json
@@ -180,7 +182,7 @@ impl GlobalArgs {
         use std::io::IsTerminal;
         if args.iter().any(|a| a == "-j" || a == "--json-output") {
             OutputFormat::Json
-        } else if args.iter().any(|a| a == "-t" || a == "--toon-output") {
+        } else if args.iter().any(|a| a == "-t" || a == "--toon-output") || is_agent_environment() {
             OutputFormat::Toon
         } else if should_auto_json() && !std::io::stdout().is_terminal() {
             OutputFormat::Json
@@ -257,6 +259,20 @@ pub fn parse_cli<T: clap::Parser + clap::CommandFactory>() -> T {
 /// Whether auto-JSON detection is enabled (disabled by `TEMPO_NO_AUTO_JSON=1`).
 fn should_auto_json() -> bool {
     std::env::var("TEMPO_NO_AUTO_JSON").is_err()
+}
+
+/// Environment variables that LLM agent hosts set.
+const AGENT_ENV_VARS: &[&str] = &[
+    "AGENT",           // Generic agent flag
+    "CLAUDE_CODE",     // Claude Code
+    "CODEX",           // OpenAI Codex CLI
+    "AMP_THREAD_ID",   // Amp
+    "CURSOR_TRACE_ID", // Cursor
+];
+
+/// Returns `true` when the process is running inside an LLM coding agent.
+fn is_agent_environment() -> bool {
+    AGENT_ENV_VARS.iter().any(|v| std::env::var(v).is_ok())
 }
 
 /// Recursively describe a clap `Command` as a JSON value.

--- a/crates/tempo-request/src/query/output.rs
+++ b/crates/tempo-request/src/query/output.rs
@@ -415,6 +415,21 @@ mod tests {
     fn no_output_flags_means_no_file() {
         // Disable auto-JSON so the test works in non-TTY CI environments
         std::env::set_var("TEMPO_NO_AUTO_JSON", "1");
+        // Disable agent-detection so the test works inside LLM agent hosts
+        let saved: Vec<_> = [
+            "AGENT",
+            "CLAUDE_CODE",
+            "CODEX",
+            "AMP_THREAD_ID",
+            "CURSOR_TRACE_ID",
+        ]
+        .iter()
+        .filter_map(|k| std::env::var(k).ok().map(|v| (*k, v)))
+        .collect();
+        for (k, _) in &saved {
+            std::env::remove_var(k);
+        }
+
         let (c, q) = parse(&["https://example.com/path/file.txt"]);
         let url = Url::parse(&q.url).unwrap();
 
@@ -425,6 +440,9 @@ mod tests {
             &url,
         );
         std::env::remove_var("TEMPO_NO_AUTO_JSON");
+        for (k, v) in &saved {
+            std::env::set_var(k, v);
+        }
         assert!(opts.output_file.is_none());
         assert!(!opts.include_headers);
         assert_eq!(opts.output_format, OutputFormat::Text);

--- a/crates/tempo-test/src/command.rs
+++ b/crates/tempo-test/src/command.rs
@@ -33,6 +33,14 @@ pub fn make_test_command(binary_path: std::path::PathBuf, temp_dir: &TempDir) ->
     // Disable auto-JSON detection (tests capture stdout, which is not a TTY)
     cmd.env("TEMPO_NO_AUTO_JSON", "1");
 
+    // Clear agent env vars so tests don't auto-select TOON when run inside
+    // an LLM agent host (Amp, Claude Code, Codex, Cursor, etc.)
+    cmd.env_remove("AGENT");
+    cmd.env_remove("CLAUDE_CODE");
+    cmd.env_remove("CODEX");
+    cmd.env_remove("AMP_THREAD_ID");
+    cmd.env_remove("CURSOR_TRACE_ID");
+
     cmd
 }
 


### PR DESCRIPTION
## Summary

Auto-detect LLM agent environments and default to TOON output — no need to pass `-t` explicitly.

## Changes

- Check `AGENT`, `CLAUDE_CODE`, `CODEX`, `AMP_THREAD_ID`, `CURSOR_TRACE_ID` env vars in both `resolve_output_format()` and `resolve_output_format_from_argv()`
- When any is set and no explicit `--json-output`/`--toon-output` flag is given, default to TOON
- Updated test helper (`make_test_command`) to clear agent env vars so tests remain isolated
- Fixed `no_output_flags_means_no_file` unit test to save/restore agent env vars

## Testing

`make check` passes — fmt, clippy, all tests, doc, typos, deny.

Co-Authored-By: zhygis <5236121+Zygimantass@users.noreply.github.com>

Prompted by: zygis