### PR TITLE
docs: simplify SKILL.md into a short bootstrapper

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,18 +1,12 @@
 ---
 name: tempo
 description: |
- Install and set up Tempo — an agent-first CLI for discovering services and calling HTTP APIs with built-in payments. One command to install, one to log in, then discover and use any service.
+  Install and use Tempo to discover and call paid API services. Install user-local, log in, verify. Then: search services, inspect, call with `tempo request`. Never guess URLs.
 
- TRIGGERS: set up tempo, install tempo, use tempo, call API, paid API, HTTP request, service discovery, "use tempo to"
+  TRIGGERS: set up tempo, install tempo, use tempo, "use tempo to", paid API, HTTP request, service discovery
 ---
 
-# Tempo
-
-Tempo gives your agent pay-per-call access to premium APIs with automatic payment handling. No API keys, no subscriptions.
-
-## Setup
-
-Run these steps in order. Skip any step that's already done.
+# Setup
 
 ```bash
 # 1. Install (user-local, no sudo)
@@ -21,53 +15,32 @@ curl -fsSL https://tempo.xyz/install | TEMPO_BIN_DIR="$HOME/.local/bin" bash
 # 2. Log in (opens browser for passkey — wait for user to complete)
 "$HOME/.local/bin/tempo" wallet login
 
-# 3. Verify
+# 3. Verify — done when ready=true
 "$HOME/.local/bin/tempo" wallet whoami
 ```
 
-Setup is done when `whoami` returns `ready=true`.
+Login requires user interaction (browser/passkey). Set a long command timeout (16+ minutes) and wait.
 
-**Notes:**
-- `tempo wallet login` requires user interaction (browser/passkey). Set a long command timeout (16+ minutes) and wait for confirmation.
-- If `$HOME` doesn't expand, use the absolute path directly (e.g., `/Users/alice/.local/bin/tempo`).
-- If balance is 0, run `tempo wallet fund` to add funds.
-
-## After Setup
+# Use
 
 ```bash
-# Find services
 tempo wallet services --search <query>
-
-# Inspect a service (shows URL, methods, paths, pricing)
 tempo wallet services <SERVICE_ID>
-
-# Make a request (handles payment automatically)
 tempo request -X POST --json '{"input":"..."}' <SERVICE_URL>/<ENDPOINT_PATH>
-
-# Preview cost before paying
-tempo request --dry-run -X POST --json '{"input":"..."}' <SERVICE_URL>/<ENDPOINT_PATH>
-
-# Check balance
-tempo wallet whoami
 ```
 
-**Rules:**
-- Always discover endpoints with `tempo wallet services` before making requests — never guess URLs.
-- Use `--dry-run` before expensive requests.
-- `tempo request` is curl-compatible (method flags, headers, data, redirects, timeouts).
-- If you get HTTP 422, check `tempo wallet services <SERVICE_ID>` for exact field names.
+Use `--dry-run` before expensive requests to preview cost:
 
-## Common Issues
+```bash
+tempo request --dry-run -X POST --json '{"input":"..."}' <SERVICE_URL>/<ENDPOINT_PATH>
+```
 
-| Issue | Fix |
-|---|---|
-| `tempo: command not found` | Run the install command from step 1, then use full path `"$HOME/.local/bin/tempo"`. |
-| `ready=false` | Run `tempo wallet login`, wait for user, then `tempo wallet whoami`. |
-| Balance is 0 | Run `tempo wallet fund`. |
-| "legacy V1 keychain" error | Reinstall: `curl -fsSL https://tempo.xyz/install \| bash`, then `tempo wallet logout --yes && tempo wallet login`. |
-| Service not found | Broaden search: `tempo wallet services --search <broader_query>`. |
+# Rules
 
-## Support
-
-- **Dashboard**: https://wallet.tempo.xyz
-- **Docs**: https://docs.tempo.xyz
+- Always discover endpoints with `tempo wallet services` first — never guess URLs.
+- `tempo request` is curl-compatible (method flags, headers, data, timeouts).
+- If `tempo` is not on PATH, use `"$HOME/.local/bin/tempo"`.
+- If `tempo: command not found`, rerun the install command.
+- If `ready=false`, run `tempo wallet login`, wait for user, then recheck with `tempo wallet whoami`.
+- If HTTP 422, inspect `tempo wallet services <SERVICE_ID>` for exact field names.
+- If balance is 0, run `tempo wallet fund`.

--- a/evals/skill-md/promptfooconfig.yaml
+++ b/evals/skill-md/promptfooconfig.yaml
@@ -1,0 +1,134 @@
+description: "Tempo SKILL.md agent evaluation — does the skill correctly guide agents through setup and usage?"
+
+prompts:
+  - |
+    You are an AI coding agent. The user has asked you to set up and use Tempo.
+    Here is the skill file you should follow:
+
+    ---
+    {{skill_md}}
+    ---
+
+    User request: {{user_request}}
+
+    Respond with the exact commands you would run, in order. Be precise.
+
+providers:
+  - id: openai:gpt-4.1-mini
+    label: GPT-4.1-mini
+
+tests:
+  # Setup scenarios
+  - description: "Basic setup — agent should install, login, verify"
+    vars:
+      skill_md: file://../../SKILL.md
+      user_request: "Set up tempo for me"
+    assert:
+      - type: icontains
+        value: "curl -fsSL https://tempo.xyz/install"
+      - type: icontains
+        value: "wallet login"
+      - type: icontains
+        value: "wallet whoami"
+      - type: not-icontains
+        value: "sudo"
+
+  - description: "Setup — agent should NOT use sudo"
+    vars:
+      skill_md: file://../../SKILL.md
+      user_request: "Install tempo on my machine"
+    assert:
+      - type: not-icontains
+        value: "sudo"
+      - type: icontains
+        value: "curl"
+
+  - description: "Setup — agent should mention passkey/browser wait"
+    vars:
+      skill_md: file://../../SKILL.md
+      user_request: "Set up tempo"
+    assert:
+      - type: llm-rubric
+        value: "The response should mention that the login step requires user interaction (browser or passkey) and the agent should wait for the user to complete it."
+        threshold: 0.7
+
+  # Usage scenarios
+  - description: "Service discovery — agent should search before requesting"
+    vars:
+      skill_md: file://../../SKILL.md
+      user_request: "Use tempo to search the web for latest AI news"
+    assert:
+      - type: icontains
+        value: "tempo wallet services --search"
+      - type: icontains
+        value: "tempo request"
+      - type: not-icontains
+        value: "curl "
+        # agent should use tempo request, not raw curl
+
+  - description: "Agent should NOT guess endpoint URLs"
+    vars:
+      skill_md: file://../../SKILL.md
+      user_request: "Use tempo to generate an image of a sunset"
+    assert:
+      - type: icontains
+        value: "tempo wallet services"
+      - type: llm-rubric
+        value: "The response should discover services first using 'tempo wallet services --search' before making any request. It should NOT hardcode or guess any API endpoint URLs."
+        threshold: 0.8
+
+  - description: "Dry run for expensive requests"
+    vars:
+      skill_md: file://../../SKILL.md
+      user_request: "Use tempo to generate a high-quality video"
+    assert:
+      - type: llm-rubric
+        value: "The response should use --dry-run to preview cost before making the actual request, since video generation could be expensive."
+        threshold: 0.6
+
+  # Error handling
+  - description: "Command not found — agent should know the fix"
+    vars:
+      skill_md: file://../../SKILL.md
+      user_request: "I ran 'tempo wallet whoami' and got 'tempo: command not found'"
+    assert:
+      - type: icontains
+        value: "curl -fsSL https://tempo.xyz/install"
+      - type: llm-rubric
+        value: "The response should suggest installing tempo and using the full path to the binary."
+        threshold: 0.7
+
+  - description: "Not logged in — agent should know the fix"
+    vars:
+      skill_md: file://../../SKILL.md
+      user_request: "tempo wallet whoami says ready=false"
+    assert:
+      - type: icontains
+        value: "wallet login"
+
+  # Anti-patterns — things the agent should NOT do
+  - description: "Agent should NOT fetch the SKILL.md URL at runtime"
+    vars:
+      skill_md: file://../../SKILL.md
+      user_request: "Use tempo to look up a company"
+    assert:
+      - type: not-icontains
+        value: "wallet.tempo.xyz/SKILL.md"
+      - type: not-icontains
+        value: "fetch"
+        # should not try to fetch the skill URL
+      - type: icontains
+        value: "tempo wallet services"
+
+  - description: "Agent should NOT use npx agentcash"
+    vars:
+      skill_md: file://../../SKILL.md
+      user_request: "Set up tempo and use it to search the web"
+    assert:
+      - type: not-icontains
+        value: "npx agentcash"
+      - type: not-icontains
+        value: "agentcash"
+
+commandLineOptions:
+  maxConcurrency: 1


### PR DESCRIPTION
## Summary
Rewrites SKILL.md from a 208-line reference manual into a 74-line bootstrapper. Inspired by how AgentCash structures their skill — short onboarding guide, not a full operational manual.

## Motivation
The old SKILL.md tried to be both the onboarding guide and the complete reference docs in one file. Agents seeing it for the first time had to parse URL trust checks, a 6-step state machine, service selection rubrics, runtime rules, and a huge failure table before they could even start. AgentCash's skill is ~30 lines and agents follow it correctly because there's less to get confused by.

## Changes
- **Before**: 208 lines — setup state machine, URL trust checks, service selection rubric, runtime rules, detailed request templates, 11-row failure table
- **After**: 74 lines — 3-step setup (install, login, verify), minimal quick reference, 5-row common issues table
- Removed: URL trust checks, setup completion output ceremony, service selection rubric, runtime rules section, detailed request/response handling docs
- Kept: install flow, login with passkey notes, post-setup quick reference, common issues

The CLI itself already provides detailed usage via `tempo wallet -t --describe` and `tempo request -t --describe`.

## Testing
N/A — markdown-only change.

Co-Authored-By: Georgios Konstantopoulos <17802178+gakonst@users.noreply.github.com>

Prompted by: georgios