### PR TITLE
chore: update moderato escrow contract address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,7 +918,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -2257,7 +2257,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2406,7 +2406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3102,7 +3102,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.5.0"
-source = "git+https://github.com/tempoxyz/mpp-rs.git?branch=main#994904f44d6b9f9b27f36c0a012c0902505d2316"
+source = "git+https://github.com/tempoxyz/mpp-rs.git?branch=main#97bebefe1f5e7a72142be12496606c3d0e2aeedb"
 dependencies = [
  "alloy",
  "alloy-signer-local",
@@ -3785,7 +3785,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4573,7 +4573,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4610,9 +4610,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5662,7 +5662,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6478,7 +6478,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6544,7 +6544,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
+source = "git+https://github.com/tempoxyz/tempo#2362da37c2b773ea13b31e388e6debf1d0d6e5de"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -6555,7 +6555,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
+source = "git+https://github.com/tempoxyz/tempo#2362da37c2b773ea13b31e388e6debf1d0d6e5de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/crates/tempo-common/src/network.rs
+++ b/crates/tempo-common/src/network.rs
@@ -26,7 +26,7 @@ pub const USDCE_TOKEN: Address = address!("20c000000000000000000000b9537d11c60e8
 /// Escrow contract address (mainnet).
 const TEMPO_ESCROW: Address = address!("33b901018174ddabe4841042ab76ba85d4e24f25");
 /// Escrow contract address (moderato testnet).
-const TEMPO_MODERATO_ESCROW: Address = address!("542831e3e4ace07559b7c8787395f4fb99f70787");
+pub const TEMPO_MODERATO_ESCROW: Address = address!("e1c4d3dce17bc111181ddf716f75bae49e61a336");
 
 /// Token configuration for Tempo mainnet (USDC).
 const TEMPO_TOKEN: TokenConfig = TokenConfig {

--- a/crates/tempo-request/src/query/challenge.rs
+++ b/crates/tempo-request/src/query/challenge.rs
@@ -244,7 +244,7 @@ mod tests {
             "currency": "0x20c0000000000000000000000000000000000000",
             "recipient": "0x1111111111111111111111111111111111111111",
             "methodDetails": {
-                "escrowContract": "0x542831e3e4ace07559b7c8787395f4fb99f70787"
+                "escrowContract": tempo_common::network::TEMPO_MODERATO_ESCROW.to_string()
             }
         }))
         .unwrap();
@@ -298,7 +298,7 @@ mod tests {
                 "recipient": "0x1111111111111111111111111111111111111111",
                 "methodDetails": {
                     "chainId": 4217,
-                    "escrowContract": "0x542831e3e4ace07559b7c8787395f4fb99f70787"
+                    "escrowContract": tempo_common::network::TEMPO_MODERATO_ESCROW.to_string()
                 }
             }),
         );

--- a/crates/tempo-request/tests/session/harness.rs
+++ b/crates/tempo-request/tests/session/harness.rs
@@ -22,7 +22,7 @@ use tempo_common::keys::parse_private_key_signer;
 use crate::common::test_command;
 use tempo_test::MODERATO_PRIVATE_KEY;
 
-pub(crate) const MODERATO_ESCROW: &str = "0x542831e3e4ace07559b7c8787395f4fb99f70787";
+use tempo_common::network::TEMPO_MODERATO_ESCROW;
 pub(crate) const MODERATO_TOKEN: &str = "0x20c0000000000000000000000000000000000000";
 pub(crate) const PAYEE_A: &str = "0x1111111111111111111111111111111111111111";
 pub(crate) const PAYEE_B: &str = "0x2222222222222222222222222222222222222222";
@@ -472,7 +472,7 @@ async fn session_handler(
             "recipient"
         };
         let mut method_details = serde_json::json!({
-            "escrowContract": MODERATO_ESCROW,
+            "escrowContract": TEMPO_MODERATO_ESCROW.to_string(),
         });
         if !path.contains("missing-chain-id") {
             method_details["chainId"] = serde_json::json!(42431);

--- a/crates/tempo-wallet/tests/session/mod.rs
+++ b/crates/tempo-wallet/tests/session/mod.rs
@@ -17,7 +17,7 @@ use serde_json::json;
 use super::*;
 use tempo_test::{corrupt_local_session_deposit, seed_local_session};
 
-const MODERATO_ESCROW: &str = "0x542831e3e4ace07559b7c8787395f4fb99f70787";
+use tempo_common::network::TEMPO_MODERATO_ESCROW;
 const MODERATO_TOKEN: &str = "0x20c0000000000000000000000000000000000000";
 const CHANNEL_OPENED_TOPIC: &str =
     "0xcd6e60364f8ee4c2b0d62afc07a1fb04fd267ce94693f93f8f85daaa099b5c94";
@@ -376,7 +376,7 @@ fn channel_opened_log(channel_id: &str) -> serde_json::Value {
 
     json!({
         "removed": false,
-        "address": MODERATO_ESCROW,
+        "address": TEMPO_MODERATO_ESCROW.to_string(),
         "data": format!("0x{}", hex::encode(data)),
         "topics": [
             CHANNEL_OPENED_TOPIC,
@@ -426,7 +426,7 @@ fn seed_session_for_close(
          WHERE channel_id = ?7",
         rusqlite::params![
             request_url,
-            MODERATO_ESCROW,
+            TEMPO_MODERATO_ESCROW.to_string(),
             MODERATO_TOKEN,
             SEEDED_PAYER,
             cumulative_amount.to_string(),
@@ -485,7 +485,7 @@ fn insert_session_for_close(
             channel_id,
             origin,
             request_url,
-            MODERATO_ESCROW,
+            TEMPO_MODERATO_ESCROW.to_string(),
             MODERATO_TOKEN,
             "0x0000000000000000000000000000000000000002",
             SEEDED_PAYER,


### PR DESCRIPTION
Update testnet escrow to `0xe1c4d3dce17bc111181ddf716f75bae49e61a336`.

- Export `TEMPO_MODERATO_ESCROW_STR` from `tempo-common::network` as the single source of truth
- Replace hardcoded escrow strings in test files with the shared constant
- Bump mpp-rs to latest main (includes the same address update)