### PR TITLE
fix: use full commit SHA for changelogs action refs

### DIFF
--- a/.changelog/config.toml
+++ b/.changelog/config.toml
@@ -12,4 +12,4 @@ format = "root"
 
 # AI-assisted changelog generation
 [ai]
-command = "amp -p"
+command = "claude -p"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Configure git auth
         run: git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
 
-      - uses: tempoxyz/changelogs@changelogs@0.6.2 # aae9b474
+      - uses: tempoxyz/changelogs@aae9b474ba053648354bea3f9b8670cac4c78ba1 # changelogs@0.6.2
         with:
           conventional-commit: true
           github-token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
The tag name `changelogs@0.6.2` contains `@` which conflicts with GitHub Actions' `{org}/{repo}@ref` syntax, causing the release workflow to fail silently on every push to main.

### Changes
- **`release.yml`**: Replace `tempoxyz/changelogs@changelogs@0.6.2` with full SHA `aae9b474ba053648354bea3f9b8670cac4c78ba1`
- **`.changelog/config.toml`**: Update default AI command from `amp -p` to `claude -p`