### PR TITLE
fix: respect changelog label bump level and use bot for release PRs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-      - uses: tempoxyz/changelogs/check@aae9b474ba053648354bea3f9b8670cac4c78ba1 # changelogs@0.6.2
+      - uses: tempoxyz/changelogs/check@433ce44f6e3ec148a2e1fa5789f22c0db21ac6da # changelogs@0.6.2 + multiline fix
 
   generate:
     if: >-
@@ -52,12 +52,20 @@ jobs:
         if: steps.existing.outputs.found == 'false'
         run: npm install -g @anthropic-ai/claude-code
 
+      - name: Extract bump level from label
+        if: steps.existing.outputs.found == 'false'
+        id: bump
+        run: echo "level=${LABEL#changelog:}" >> "$GITHUB_OUTPUT"
+        env:
+          LABEL: ${{ github.event.label.name }}
+
       - name: Generate changelog
         if: steps.existing.outputs.found == 'false'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          changelogs add --ai "claude -p" --ref "origin/${{ github.base_ref }}"
+          changelogs add --ai "claude -p" --ref "origin/${{ github.base_ref }}" \
+            --instructions "Use '${{ steps.bump.outputs.level }}' as the bump level for all changed packages. Do not use a higher bump level."
 
       - name: Commit changelog
         if: steps.existing.outputs.found == 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Configure git auth
         run: git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
 
-      - uses: tempoxyz/changelogs@aae9b474ba053648354bea3f9b8670cac4c78ba1 # changelogs@0.6.2
+      - uses: tempoxyz/changelogs@433ce44f6e3ec148a2e1fa5789f22c0db21ac6da # changelogs@0.6.2 + multiline fix
         id: changelogs
         with:
           conventional-commit: true
-          github-token: ${{ secrets.GH_PAT }}
+          github-token: ${{ github.token }}
 
       - name: Update Cargo.lock on release PR
         if: steps.changelogs.outputs.pullRequestNumber != ''


### PR DESCRIPTION
Two fixes to changelog/release workflows:

1. **Pass bump level from label to AI** — The `changelog:patch` label triggered changelog generation but never told the AI to use `patch`. The AI would auto-determine the bump level (e.g., choosing `minor` for feature-like changes). Now extracts the level from the label and passes it via `--instructions`.

2. **Use `github.token` for release PR creation** — Release PRs were authored by `brendanjryan` because `GH_PAT` (a personal token) was used for the changelogs action. Now uses `github.token` so the PR shows as `github-actions[bot]`. `GH_PAT` is still used for checkout and git config (needed for private dependency access).