### PR TITLE
fix: sync tempo-wallet and tempo-request versions

### DIFF
--- a/.changelog/config.toml
+++ b/.changelog/config.toml
@@ -2,6 +2,10 @@
 # "patch" | "minor" | "none"
 dependent_bump = "patch"
 
+# Packages that must always share the same version
+[[fixed]]
+members = ["tempo-wallet", "tempo-request"]
+
 # Packages to ignore (internal-only, not released)
 ignore = ["tempo-common", "tempo-sign", "tempo-test"]
 


### PR DESCRIPTION
Adds a `[[fixed]]` group to the changelogs config so `tempo-wallet` and `tempo-request` always share the same version. If only one package is mentioned in a changelog entry, the other is automatically bumped to match.

Verified locally with `changelogs version --dry-run` — a changelog mentioning only `tempo-wallet: patch` correctly bumps both to `0.1.2`.