### PR TITLE
fix: preserve original error on key-auth retry and ensure deposit covers request cost

### DIFF
--- a/crates/tempo-common/src/error.rs
+++ b/crates/tempo-common/src/error.rs
@@ -346,6 +346,8 @@ pub enum PaymentError {
         #[source]
         source: Box<TempoError>,
     },
+    #[error("Deposit too low for request: deposit is {deposit} but request costs {amount}")]
+    DepositInsufficient { deposit: String, amount: String },
     #[error("session stream idle timeout after {timeout_secs}s")]
     SessionStreamIdleTimeout { timeout_secs: u64 },
     #[error("session voucher retries exhausted after {max_retries} attempts")]

--- a/crates/tempo-common/src/payment/session/tx.rs
+++ b/crates/tempo-common/src/payment/session/tx.rs
@@ -121,7 +121,7 @@ pub async fn resolve_and_sign_tx_with_fee_payer(
 
     let gas_limit = match gas_result {
         Ok(gas) => gas,
-        Err(_) if wallet.has_stored_key_authorization() => {
+        Err(original) if wallet.has_stored_key_authorization() => {
             provisioning_signer =
                 wallet
                     .with_key_authorization()
@@ -146,9 +146,9 @@ pub async fn resolve_and_sign_tx_with_fee_payer(
                 valid_before,
             )
             .await
-            .map_err(|source| KeyError::SigningOperationSource {
-                operation: "estimate gas (retry with key provisioning)",
-                source: Box::new(source),
+            .map_err(|_| KeyError::SigningOperationSource {
+                operation: "estimate gas",
+                source: Box::new(original),
             })?
         }
         Err(e) => {
@@ -208,7 +208,7 @@ pub async fn submit_tempo_tx(
 
     match provider.send_raw_transaction(&tx_bytes).await {
         Ok(pending) => Ok(format!("{:#x}", pending.tx_hash())),
-        Err(_) if wallet.has_stored_key_authorization() => {
+        Err(original) if wallet.has_stored_key_authorization() => {
             let provisioning_signer =
                 wallet
                     .with_key_authorization()
@@ -229,9 +229,9 @@ pub async fn submit_tempo_tx(
             let pending = provider
                 .send_raw_transaction(&retry_bytes)
                 .await
-                .map_err(|source| NetworkError::RpcSource {
+                .map_err(|_| NetworkError::RpcSource {
                     operation: "broadcast transaction",
-                    source: Box::new(source),
+                    source: Box::new(original),
                 })?;
             Ok(format!("{:#x}", pending.tx_hash()))
         }

--- a/crates/tempo-request/src/payment/charge.rs
+++ b/crates/tempo-request/src/payment/charge.rs
@@ -59,7 +59,7 @@ pub(super) async fn handle_charge_request(
 
     let credential = match provider.pay(challenge).await {
         Ok(cred) => cred,
-        Err(_) if signer.has_stored_key_authorization() => {
+        Err(original) if signer.has_stored_key_authorization() => {
             let provisioning_signer =
                 signer
                     .with_key_authorization()
@@ -80,7 +80,7 @@ pub(super) async fn handle_charge_request(
             retry_provider
                 .pay(challenge)
                 .await
-                .map_err(|e| classify_payment_error(e, &resolved.network_id))?
+                .map_err(|_| classify_payment_error(original, &resolved.network_id))?
         }
         Err(e) => return Err(classify_payment_error(e, &resolved.network_id)),
     };

--- a/crates/tempo-request/src/payment/session/flow.rs
+++ b/crates/tempo-request/src/payment/session/flow.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use alloy::primitives::{Address, B256};
+use alloy::primitives::{utils::parse_units, Address, B256};
 use mpp::protocol::methods::tempo::{compute_channel_id, session::TempoSessionExt, sign_voucher};
 
 use super::{
@@ -861,12 +861,14 @@ async fn deposit_stage(
     resolved: &ResolvedChallenge,
     challenge: &ResolvedSessionChallenge,
 ) -> Result<DepositStageOutput, TempoError> {
-    let base_units: u128 = 10u128.saturating_pow(u32::from(challenge.network_id.token().decimals));
-    let max_deposit: u128 = 5u128.saturating_mul(base_units);
+    let decimals = challenge.network_id.token().decimals;
+    let default_deposit: u128 = parse_units("1", decimals).unwrap().get_absolute().to();
+    let max_deposit: u128 = parse_units("5", decimals).unwrap().get_absolute().to();
 
     let mut deposit = challenge
         .suggested_deposit
-        .unwrap_or(base_units)
+        .unwrap_or(default_deposit)
+        .max(challenge.amount)
         .min(max_deposit);
     let mut clamped_deposit = None;
 
@@ -1200,7 +1202,7 @@ async fn open_stage(
     .await
     {
         Ok(resp) => resp,
-        Err(_) if signer.has_stored_key_authorization() => {
+        Err(original) if signer.has_stored_key_authorization() => {
             let provisioning_signer =
                 signer
                     .with_key_authorization()
@@ -1222,7 +1224,8 @@ async fn open_stage(
                 &open_idempotency_key,
                 &delays,
             )
-            .await?
+            .await
+            .map_err(|_| original)?
         }
         Err(e) => return Err(e),
     };
@@ -1291,6 +1294,14 @@ pub(crate) async fn handle_session_request(
             ReuseStageOutcome::Reused(result) => return Ok(result.payment),
             ReuseStageOutcome::NeedsOpen => {}
         }
+    }
+
+    if deposit.deposit < challenge.amount {
+        return Err(PaymentError::DepositInsufficient {
+            deposit: format_token_amount(deposit.deposit, challenge.network_id),
+            amount: format_token_amount(challenge.amount, challenge.network_id),
+        }
+        .into());
     }
 
     let mut opened = open_stage(http, url, &resolved, &signer, &challenge, &deposit).await?;

--- a/crates/tempo-request/tests/session/harness.rs
+++ b/crates/tempo-request/tests/session/harness.rs
@@ -307,25 +307,35 @@ fn session_rpc_response(
         "eth_gasPrice" => json!("0x4a817c800"),
         "eth_getBalance" => json!("0xde0b6b3a7640000"),
         "eth_call" => {
-            let mut guard = observations.lock().unwrap();
-            guard.eth_call_count += 1;
-            let mode = match config.channel_mode {
-                SessionRpcChannelMode::Active => SessionRpcChannelMode::Active,
-                SessionRpcChannelMode::Missing => SessionRpcChannelMode::Missing,
-                SessionRpcChannelMode::ActiveThenMissingAfterEthCalls { threshold } => {
-                    if guard.eth_call_count > threshold {
-                        SessionRpcChannelMode::Missing
-                    } else {
-                        SessionRpcChannelMode::Active
-                    }
-                }
-            };
+            // balanceOf(address) selector = 0x70a08231
+            let calldata = req["params"][0]["data"]
+                .as_str()
+                .or_else(|| req["params"][0]["input"].as_str())
+                .unwrap_or("");
 
-            match mode {
-                SessionRpcChannelMode::Active => json!(encode_active_channel_return_data()),
-                SessionRpcChannelMode::Missing => json!(encode_missing_channel_return_data()),
-                SessionRpcChannelMode::ActiveThenMissingAfterEthCalls { .. } => {
-                    unreachable!("mode should be normalized before matching")
+            if calldata.starts_with("0x70a08231") {
+                json!(format!("0x{:064x}", 10_000_000_u128)) // 10 tokens
+            } else {
+                let mut guard = observations.lock().unwrap();
+                guard.eth_call_count += 1;
+                let mode = match config.channel_mode {
+                    SessionRpcChannelMode::Active => SessionRpcChannelMode::Active,
+                    SessionRpcChannelMode::Missing => SessionRpcChannelMode::Missing,
+                    SessionRpcChannelMode::ActiveThenMissingAfterEthCalls { threshold } => {
+                        if guard.eth_call_count > threshold {
+                            SessionRpcChannelMode::Missing
+                        } else {
+                            SessionRpcChannelMode::Active
+                        }
+                    }
+                };
+
+                match mode {
+                    SessionRpcChannelMode::Active => json!(encode_active_channel_return_data()),
+                    SessionRpcChannelMode::Missing => json!(encode_missing_channel_return_data()),
+                    SessionRpcChannelMode::ActiveThenMissingAfterEthCalls { .. } => {
+                        unreachable!("mode should be normalized before matching")
+                    }
                 }
             }
         }

--- a/crates/tempo-request/tests/session/lifecycle.rs
+++ b/crates/tempo-request/tests/session/lifecycle.rs
@@ -447,7 +447,7 @@ async fn run_invalidating_problem_reopen_case(problem_type: &'static str) {
     let (temp, observed, second_output, first_channel_id) = run_invalidating_problem_case(
         problem_type,
         SessionRpcConfig {
-            channel_mode: SessionRpcChannelMode::ActiveThenMissingAfterEthCalls { threshold: 3 },
+            channel_mode: SessionRpcChannelMode::ActiveThenMissingAfterEthCalls { threshold: 1 },
         },
     )
     .await;
@@ -516,7 +516,7 @@ async fn run_invalidating_problem_unconfirmed_case(problem_type: &'static str) {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn channel_not_found_problem_with_delete_failure_fails_closed_without_reopen() {
     let rpc = SessionRpcServer::start_with_config(SessionRpcConfig {
-        channel_mode: SessionRpcChannelMode::ActiveThenMissingAfterEthCalls { threshold: 3 },
+        channel_mode: SessionRpcChannelMode::ActiveThenMissingAfterEthCalls { threshold: 1 },
     })
     .await;
     let server = SessionServer::start(SessionServerConfig {


### PR DESCRIPTION
## Summary

Fixes two issues encountered when using high-cost session endpoints (e.g. Veo video generation at 3.5 USDC/request):

### 1. Key-auth retry hides original error
When the optimistic path (without key authorization) fails and the retry with key authorization also fails, the **retry error** was surfaced instead of the **original error**. This caused confusing messages like `KeyAlreadyExists` when the real issue was something else entirely.

**Fix:** All 4 retry sites now capture the original error and return it when the retry also fails:
- `tx.rs`: `estimate_gas` and `submit_tempo_tx`
- `flow.rs`: `open_stage` channel open
- `charge.rs`: charge payment

### 2. Session deposit doesn't cover request cost
The default session deposit is 1 USDC, but some endpoints cost more (e.g. 3.5 USDC for Veo). The channel would open with 1 USDC, then immediately fail with `insufficient-balance` — wasting gas on a channel that can never serve even one request.

**Fix:**
- Deposit is now `max(suggested_deposit ∥ 1 USDC, challenge.amount)`, capped at 5 USDC
- If after wallet balance clamping the deposit is still below the request cost, fail **before** opening the channel
- Replaced manual `10^decimals` arithmetic with alloy's `parse_units` for readability

### 3. Test harness fix
Mock RPC now differentiates `balanceOf` (ERC-20, selector `0x70a08231`) calls from channel queries, returning a realistic token balance instead of channel data that decodes to zero.