### PR TITLE
fix: tighten charge retry scope and show full rejection body

### DIFF
--- a/.changelog/fix-charge-retry-and-rejection-errors.md
+++ b/.changelog/fix-charge-retry-and-rejection-errors.md
@@ -1,0 +1,5 @@
+---
+tempo-request: patch
+---
+
+Tighten charge payment provisioning retry to only fire on auth/payment (401–403) and server error (5xx) status codes, avoiding wasteful retries on unrelated API errors like 400 body validation. Show full server response body in payment rejection errors instead of extracting a single JSON field. Ensure all retry paths surface the original error on retry failure.

--- a/crates/tempo-common/src/payment/classify.rs
+++ b/crates/tempo-common/src/payment/classify.rs
@@ -94,22 +94,6 @@ pub fn parse_problem_details(body: &str) -> Option<ProblemDetails> {
     Some(problem)
 }
 
-/// Extract the first meaningful error string from a JSON response body.
-///
-/// Checks `error`, `message`, and `detail` fields in order.
-pub fn extract_json_error(body: &str) -> Option<String> {
-    if let Some(problem) = parse_problem_details(body) {
-        return Some(problem.message());
-    }
-
-    let json: serde_json::Value = serde_json::from_str(body).ok()?;
-    json.get("error")
-        .or_else(|| json.get("message"))
-        .or_else(|| json.get("detail"))
-        .and_then(|v| v.as_str())
-        .map(String::from)
-}
-
 /// Map mpp validation errors to tempo-wallet error types.
 #[must_use]
 pub fn map_mpp_validation_error(
@@ -421,69 +405,6 @@ mod tests {
             }
             other => panic!("Expected HttpStatus with parsed code, got: {other}"),
         }
-    }
-
-    // --- extract_json_error tests ---
-
-    #[test]
-    fn test_extract_json_error_error_field() {
-        let body = r#"{"error": "something went wrong"}"#;
-        assert_eq!(
-            extract_json_error(body),
-            Some("something went wrong".to_string())
-        );
-    }
-
-    #[test]
-    fn test_extract_json_error_problem_details_preferred() {
-        let body = r#"{"type":"https://paymentauth.org/problems/session/insufficient-balance","detail":"need top-up","message":"fallback"}"#;
-        assert_eq!(
-            extract_json_error(body),
-            Some(
-                "https://paymentauth.org/problems/session/insufficient-balance: need top-up"
-                    .to_string()
-            )
-        );
-    }
-
-    #[test]
-    fn test_extract_json_error_message_field() {
-        let body = r#"{"message": "bad request"}"#;
-        assert_eq!(extract_json_error(body), Some("bad request".to_string()));
-    }
-
-    #[test]
-    fn test_extract_json_error_detail_field() {
-        let body = r#"{"detail": "not found"}"#;
-        assert_eq!(extract_json_error(body), Some("not found".to_string()));
-    }
-
-    #[test]
-    fn test_extract_json_error_error_takes_precedence() {
-        let body = r#"{"error": "the error", "message": "the message"}"#;
-        assert_eq!(extract_json_error(body), Some("the error".to_string()));
-    }
-
-    #[test]
-    fn test_extract_json_error_no_known_fields() {
-        let body = r#"{"status": 500, "code": "INTERNAL"}"#;
-        assert_eq!(extract_json_error(body), None);
-    }
-
-    #[test]
-    fn test_extract_json_error_invalid_json() {
-        assert_eq!(extract_json_error("not json at all"), None);
-    }
-
-    #[test]
-    fn test_extract_json_error_empty_string() {
-        assert_eq!(extract_json_error(""), None);
-    }
-
-    #[test]
-    fn test_extract_json_error_non_string_field() {
-        let body = r#"{"error": 42}"#;
-        assert_eq!(extract_json_error(body), None);
     }
 
     // --- map_mpp_validation_error tests ---

--- a/crates/tempo-common/src/payment/session/close/cooperative.rs
+++ b/crates/tempo-common/src/payment/session/close/cooperative.rs
@@ -114,8 +114,11 @@ pub(super) async fn try_server_close(
             .text()
             .await
             .unwrap_or_else(|_| String::from("<no body>"));
-        let raw_reason = crate::payment::extract_json_error(&body)
-            .unwrap_or_else(|| body.chars().take(200).collect());
+        let raw_reason: String = if body.trim().is_empty() {
+            format!("HTTP {}", status.as_u16())
+        } else {
+            body.chars().take(500).collect()
+        };
         let reason = sanitize_for_terminal(&raw_reason);
         return Err(PaymentError::PaymentRejected {
             reason,

--- a/crates/tempo-request/src/payment/charge.rs
+++ b/crates/tempo-request/src/payment/charge.rs
@@ -18,6 +18,15 @@ use super::{
 };
 use tempo_common::payment::{classify_payment_error, map_mpp_validation_error};
 
+/// Whether a post-submission HTTP status code warrants a provisioning retry.
+///
+/// Only auth/payment codes (401–403) and server errors (5xx) are retried.
+/// Other 4xx codes (400 body validation, 404, 422, 429, etc.) are not
+/// payment-related and retrying with key_authorization would be wasteful.
+const fn is_retriable_payment_status(status: u16) -> bool {
+    matches!(status, 401..=403 | 500..=599)
+}
+
 /// Handle an MPP charge payment flow (402 with intent="charge").
 ///
 /// Validates the challenge, builds and signs the transaction,
@@ -94,38 +103,43 @@ pub(super) async fn handle_charge_request(
     // retry with provisioning. The server validates the transaction on-chain, and
     // it may fail when the access key isn't provisioned even though signing
     // succeeded locally (the optimistic path omits key_authorization).
-    let resp = if resp.status_code >= 400 && signer.has_stored_key_authorization() {
-        if http.log_enabled() {
-            eprintln!(
-                "Server rejected payment (HTTP {}), retrying with key authorization...",
-                resp.status_code
-            );
-        }
-        let provisioning_signer =
-            signer
-                .with_key_authorization()
-                .ok_or_else(|| KeyError::SigningOperation {
-                    operation: "key provisioning",
-                    reason: "stored key authorization could not be applied to signing mode"
-                        .to_string(),
-                })?;
-        let retry_provider = mpp::client::TempoProvider::new(
-            provisioning_signer.signer.clone(),
-            resolved.rpc_url.as_str(),
-        )
-        .map_err(|source| ConfigError::ProviderInitSource {
-            provider: "tempo payment provider (provisioning retry)",
-            source: Box::new(source),
-        })?
-        .with_signing_mode(provisioning_signer.signing_mode);
-        let retry_credential = retry_provider
-            .pay(challenge)
-            .await
-            .map_err(|e| classify_payment_error(e, &resolved.network_id))?;
-        submit_credential(http, url, &retry_credential).await?
-    } else {
-        resp
-    };
+    let resp =
+        if is_retriable_payment_status(resp.status_code) && signer.has_stored_key_authorization() {
+            if http.log_enabled() {
+                eprintln!(
+                    "Server rejected payment (HTTP {}), retrying with key authorization...",
+                    resp.status_code
+                );
+                if let Ok(body) = resp.body_string() {
+                    eprintln!("Rejection body: {}", sanitize_for_terminal(&body));
+                }
+            }
+            let provisioning_signer =
+                signer
+                    .with_key_authorization()
+                    .ok_or_else(|| KeyError::SigningOperation {
+                        operation: "key provisioning",
+                        reason: "stored key authorization could not be applied to signing mode"
+                            .to_string(),
+                    })?;
+            let retry_provider = mpp::client::TempoProvider::new(
+                provisioning_signer.signer.clone(),
+                resolved.rpc_url.as_str(),
+            )
+            .map_err(|source| ConfigError::ProviderInitSource {
+                provider: "tempo payment provider (provisioning retry)",
+                source: Box::new(source),
+            })?
+            .with_signing_mode(provisioning_signer.signing_mode);
+            let original_resp_rejection = parse_payment_rejection(&resp);
+            let retry_credential = retry_provider
+                .pay(challenge)
+                .await
+                .map_err(|_| original_resp_rejection)?;
+            submit_credential(http, url, &retry_credential).await?
+        } else {
+            resp
+        };
 
     if resp.status_code >= 400 {
         return Err(parse_payment_rejection(&resp).into());
@@ -171,21 +185,16 @@ async fn submit_credential(
     http.execute(url, &headers).await
 }
 
+/// Maximum characters to include in a payment rejection reason.
+const MAX_REJECTION_REASON_CHARS: usize = 500;
+
 /// Parse a non-200 response after payment submission into a descriptive error.
 fn parse_payment_rejection(response: &HttpResponse) -> PaymentError {
-    let raw_reason = if let Ok(body) = response.body_string() {
-        if let Some(msg) = tempo_common::payment::extract_json_error(&body) {
-            msg
-        } else if serde_json::from_str::<serde_json::Value>(&body).is_ok() {
-            // Valid JSON but no known error field
-            format!("HTTP {}", response.status_code)
-        } else if !body.trim().is_empty() {
-            body.chars().take(200).collect()
-        } else {
-            format!("HTTP {}", response.status_code)
+    let raw_reason = match response.body_string() {
+        Ok(body) if !body.trim().is_empty() => {
+            body.chars().take(MAX_REJECTION_REASON_CHARS).collect()
         }
-    } else {
-        format!("HTTP {}", response.status_code)
+        _ => format!("HTTP {}", response.status_code),
     };
     let reason = sanitize_for_terminal(&raw_reason);
 
@@ -200,8 +209,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_payment_rejection_json_error_field() {
-        let body = br#"{"error":"insufficient funds"}"#;
+    fn test_parse_payment_rejection_returns_full_json_body() {
+        let body = br#"{"error":"insufficient funds","details":"need 0.05 USDC"}"#;
         let resp = HttpResponse::for_test(400, body);
         let err = parse_payment_rejection(&resp);
         match err {
@@ -209,64 +218,9 @@ mod tests {
                 reason,
                 status_code,
             } => {
-                assert_eq!(reason, "insufficient funds");
+                assert!(reason.contains("insufficient funds"));
+                assert!(reason.contains("need 0.05 USDC"));
                 assert_eq!(status_code, 400);
-            }
-            _ => panic!("expected PaymentRejected"),
-        }
-    }
-
-    #[test]
-    fn test_parse_payment_rejection_json_message_field() {
-        let body = br#"{"message":"bad request"}"#;
-        let resp = HttpResponse::for_test(400, body);
-        let err = parse_payment_rejection(&resp);
-        match err {
-            PaymentError::PaymentRejected { reason, .. } => {
-                assert_eq!(reason, "bad request");
-            }
-            _ => panic!("expected PaymentRejected"),
-        }
-    }
-
-    #[test]
-    fn test_parse_payment_rejection_json_detail_field() {
-        let body = br#"{"detail":"validation failed"}"#;
-        let resp = HttpResponse::for_test(422, body);
-        let err = parse_payment_rejection(&resp);
-        match err {
-            PaymentError::PaymentRejected {
-                reason,
-                status_code,
-            } => {
-                assert_eq!(reason, "validation failed");
-                assert_eq!(status_code, 422);
-            }
-            _ => panic!("expected PaymentRejected"),
-        }
-    }
-
-    #[test]
-    fn test_parse_payment_rejection_json_no_known_field() {
-        let body = br#"{"foo":"bar"}"#;
-        let resp = HttpResponse::for_test(500, body);
-        let err = parse_payment_rejection(&resp);
-        match err {
-            PaymentError::PaymentRejected { reason, .. } => {
-                assert_eq!(reason, "HTTP 500");
-            }
-            _ => panic!("expected PaymentRejected"),
-        }
-    }
-
-    #[test]
-    fn test_parse_payment_rejection_json_error_precedence() {
-        let body = br#"{"error":"e","message":"m","detail":"d"}"#;
-        let resp = HttpResponse::for_test(400, body);
-        let err = parse_payment_rejection(&resp);
-        match err {
-            PaymentError::PaymentRejected { reason, .. } => {
-                assert_eq!(reason, "e");
             }
             _ => panic!("expected PaymentRejected"),
         }
@@ -286,13 +240,13 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_payment_rejection_plain_text_truncated() {
-        let body = "a".repeat(500);
+    fn test_parse_payment_rejection_truncated() {
+        let body = "a".repeat(600);
         let resp = HttpResponse::for_test(500, body.as_bytes());
         let err = parse_payment_rejection(&resp);
         match err {
             PaymentError::PaymentRejected { reason, .. } => {
-                assert_eq!(reason.len(), 200);
+                assert_eq!(reason.len(), MAX_REJECTION_REASON_CHARS);
             }
             _ => panic!("expected PaymentRejected"),
         }

--- a/crates/tempo-request/src/payment/session/error_map.rs
+++ b/crates/tempo-request/src/payment/session/error_map.rs
@@ -6,11 +6,11 @@ use tempo_common::{
 const MAX_REJECTED_REASON_CHARS: usize = 500;
 
 pub(super) fn payment_rejected_reason_from_body(body: &str) -> String {
-    let raw_reason = tempo_common::payment::extract_json_error(body).unwrap_or_else(|| {
-        body.chars()
-            .take(MAX_REJECTED_REASON_CHARS)
-            .collect::<String>()
-    });
+    let raw_reason: String = if body.trim().is_empty() {
+        "empty response".to_string()
+    } else {
+        body.chars().take(MAX_REJECTED_REASON_CHARS).collect()
+    };
     sanitize_for_terminal(&raw_reason)
 }
 
@@ -28,24 +28,17 @@ mod tests {
     use tempo_common::error::{PaymentError, TempoError};
 
     #[test]
-    fn payment_rejected_from_body_maps_common_payload_forms() {
+    fn payment_rejected_from_body_returns_full_body() {
         let oversized = "x".repeat(600);
-        let malformed = "{\"error\":\"unterminated";
         let cases = vec![
             (
-                "json_problem",
+                "json_body",
                 410,
                 r#"{"type":"https://paymentauth.org/problems/session/channel-not-found","detail":"bad\u001b[31m\u0007value"}"#
                     .to_string(),
             ),
-            (
-                "json_error",
-                402,
-                r#"{"error":"bad\u001b[31m\u0007value"}"#.to_string(),
-            ),
             ("plaintext", 500, "plain failure".to_string()),
             ("oversized", 400, oversized),
-            ("malformed", 400, malformed.to_string()),
         ];
 
         for (name, status, body) in cases {
@@ -61,16 +54,12 @@ mod tests {
                         "case={name} reason contained control bytes"
                     );
                     match name {
-                        "json_problem" => {
-                            assert_eq!(
-                                reason,
-                                "https://paymentauth.org/problems/session/channel-not-found: bad[31mvalue"
-                            );
+                        "json_body" => {
+                            assert!(reason.contains("channel-not-found"), "case={name}");
+                            assert!(reason.contains("bad"), "case={name}");
                         }
-                        "json_error" => assert_eq!(reason, "bad[31mvalue"),
                         "plaintext" => assert_eq!(reason, "plain failure"),
                         "oversized" => assert_eq!(reason.len(), 500),
-                        "malformed" => assert_eq!(reason, malformed),
                         _ => unreachable!("unexpected case"),
                     }
                 }


### PR DESCRIPTION
## Summary

Tightens charge payment provisioning retry and improves error reporting for payment rejections.

### Changes

- **Narrow retry scope**: Charge provisioning retry now only fires on auth/payment (401–403) and server error (5xx) status codes. Previously `>= 400` triggered retries on unrelated API errors like 400 body validation, wasting a retry + key_authorization on non-payment failures.

- **Show full rejection body**: Payment rejection errors now include the full server response body (truncated to 500 chars, sanitized) instead of extracting a single JSON field. This gives users complete context for debugging — e.g. validation `issues` arrays are no longer lost.

- **Fix original error surfacing**: The `submit_credential` retry path now surfaces the original server rejection on retry failure, consistent with all other retry sites in the codebase.

- **Remove `extract_json_error`**: No remaining callers after the above changes.

### Before
```
Error: Payment rejected by server: Validation failed
```

### After
```
Error: Payment rejected by server: {"success":false,"error":"Validation failed","issues":[{"expected":"array",...}]}
```
