### PR TITLE
chore: update changelogs action pin to 04ccca8

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-      - uses: tempoxyz/changelogs/check@810f56d0b08bc0ffb04287c7749cd4c91d255f38 # changelogs@0.6.2 + stricter version matching
+      - uses: tempoxyz/changelogs/check@04ccca87f4785039ced6da0fff27ba29c0dd9f5c # changelogs@0.6.3 + unified PR title + install from source
 
   generate:
     if: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Configure git auth
         run: git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
 
-      - uses: tempoxyz/changelogs@810f56d0b08bc0ffb04287c7749cd4c91d255f38 # changelogs@0.6.2 + stricter version matching
+      - uses: tempoxyz/changelogs@04ccca87f4785039ced6da0fff27ba29c0dd9f5c # changelogs@0.6.3 + unified PR title + install from source
         id: changelogs
         with:
           conventional-commit: true


### PR DESCRIPTION
Updates workflow pins to latest changelogs commit which fixes the broken release PR #336 (now closed).

**Fixes included:**
- Unified `v{version}` PR title for root changelog format
- Binary installed from action source (`cargo install --path`) instead of crates.io
- Cache key uses `github.action_ref` to properly invalidate on action updates

Once merged, the release workflow will re-run and generate a correct release PR.