### PR TITLE
fix: improve session close output

### DIFF
--- a/crates/tempo-wallet/src/commands/sessions/close.rs
+++ b/crates/tempo-wallet/src/commands/sessions/close.rs
@@ -678,6 +678,7 @@ impl CloseSummary {
         channel_id: &str,
         show_output: bool,
     ) {
+        let label = if label.is_empty() { channel_id } else { label };
         match result {
             Ok(CloseOutcome::Closed {
                 tx_url,


### PR DESCRIPTION
Add phase headers to batch close operations, fall back to channel ID for empty labels, and use normalized origin in close-by-url banner.