### PR TITLE
Use receipt spent instead of cumulative amount when closing a session

### DIFF
--- a/crates/tempo-common/src/payment/session/close/cooperative.rs
+++ b/crates/tempo-common/src/payment/session/close/cooperative.rs
@@ -256,6 +256,7 @@ mod tests {
             deposit: 1000,
             cumulative_amount: 2,
             accepted_cumulative: 0,
+            server_spent: 0,
             challenge_echo: serde_json::to_string(&mpp::ChallengeEcho {
                 id: "abc".into(),
                 realm: "test".into(),

--- a/crates/tempo-common/src/payment/session/close/mod.rs
+++ b/crates/tempo-common/src/payment/session/close/mod.rs
@@ -92,9 +92,9 @@ pub async fn close_channel_from_record(
 
     let escrow_contract: Address = record.escrow_contract;
 
-    // Use the server-confirmed accepted amount for the close voucher, not the
-    // signing ceiling, to avoid overcharging the payer.
-    let close_amount: u128 = record.accepted_cumulative_u128();
+    // Prefer the server-reported actual spend for the close voucher to avoid
+    // overcharging. Falls back to accepted_cumulative when spend is unknown.
+    let close_amount: u128 = record.close_amount();
 
     if should_attempt_cooperative_close(record) {
         let echo: ChallengeEcho =
@@ -219,7 +219,7 @@ pub async fn close_channel_from_record_cooperative(
 
     let channel_id: B256 = record.channel_id;
     let escrow_contract: Address = record.escrow_contract;
-    let close_amount: u128 = record.accepted_cumulative_u128();
+    let close_amount: u128 = record.close_amount();
 
     let client = reqwest::Client::new();
     let tx_url = cooperative::try_server_close(
@@ -288,6 +288,7 @@ mod tests {
             deposit: 0,
             cumulative_amount: 0,
             accepted_cumulative: 0,
+            server_spent: 0,
             challenge_echo: "{}".to_string(),
             state: ChannelStatus::Active,
             close_requested_at: 0,

--- a/crates/tempo-common/src/payment/session/store/model.rs
+++ b/crates/tempo-common/src/payment/session/store/model.rs
@@ -81,10 +81,15 @@ pub struct ChannelRecord {
     pub channel_id: B256,
     pub deposit: u128,
     pub cumulative_amount: u128,
-    /// Server-confirmed accepted cumulative amount. Used for cooperative close
-    /// to avoid overcharging. Defaults to `cumulative_amount` when unknown.
+    /// Server-confirmed accepted cumulative amount. Reflects the highest voucher
+    /// the server has accepted. Defaults to `cumulative_amount` when unknown.
     #[serde(default)]
     pub accepted_cumulative: u128,
+    /// Server-reported actual spend. Read from the `spent` field of the
+    /// `Payment-Receipt` header. Used for cooperative close to avoid
+    /// overcharging. Defaults to 0 when the server has not reported spend.
+    #[serde(default)]
+    pub server_spent: u128,
     pub challenge_echo: String,
     /// Explicit lifecycle state.
     #[serde(default = "default_state")]
@@ -140,7 +145,7 @@ impl ChannelRecord {
         format!("{channel_id:#x}", channel_id = self.channel_id)
     }
 
-    /// The server-confirmed accepted amount, for use in cooperative close.
+    /// The server-confirmed accepted amount.
     /// Falls back to `cumulative_amount` when the accepted amount is unknown (zero).
     #[must_use]
     pub const fn accepted_cumulative_u128(&self) -> u128 {
@@ -148,6 +153,17 @@ impl ChannelRecord {
             self.accepted_cumulative
         } else {
             self.cumulative_amount
+        }
+    }
+
+    /// The amount to use for cooperative close. Prefers the server-reported
+    /// actual spend over the accepted voucher ceiling to avoid overcharging.
+    #[must_use]
+    pub const fn close_amount(&self) -> u128 {
+        if self.server_spent > 0 {
+            self.server_spent
+        } else {
+            self.accepted_cumulative_u128()
         }
     }
 
@@ -159,6 +175,13 @@ impl ChannelRecord {
     /// Update the accepted cumulative amount (monotonic: never decreases).
     pub fn set_accepted_cumulative(&mut self, amount: u128) {
         self.accepted_cumulative = amount.max(self.accepted_cumulative);
+    }
+
+    /// Update the server-reported spend. Always takes the latest value from
+    /// the server (not monotonic — spend can be reconciled to a lower amount
+    /// when a reservation is committed at actual cost).
+    pub fn set_server_spent(&mut self, amount: u128) {
+        self.server_spent = amount;
     }
 
     /// Update `last_used_at` timestamp.
@@ -254,6 +277,7 @@ mod tests {
             deposit: 1_000_000,
             cumulative_amount: 0,
             accepted_cumulative: 0,
+            server_spent: 0,
             challenge_echo: "echo".into(),
             state: ChannelStatus::Active,
             close_requested_at: 0,
@@ -355,6 +379,27 @@ mod tests {
         assert_eq!(record.cumulative_amount, 50);
         record.set_cumulative_amount(100);
         assert_eq!(record.cumulative_amount, 100);
+    }
+
+    #[test]
+    fn test_close_amount_prefers_server_spent() {
+        let mut record = test_record("https://example.com", "salt");
+        record.cumulative_amount = 100;
+        record.accepted_cumulative = 80;
+        record.server_spent = 55;
+        assert_eq!(record.close_amount(), 55);
+    }
+
+    #[test]
+    fn test_close_amount_falls_back_when_server_spent_missing() {
+        let mut record = test_record("https://example.com", "salt");
+        record.cumulative_amount = 100;
+        record.accepted_cumulative = 80;
+        record.server_spent = 0;
+        assert_eq!(record.close_amount(), 80);
+
+        record.accepted_cumulative = 0;
+        assert_eq!(record.close_amount(), 100);
     }
 
     #[test]

--- a/crates/tempo-common/src/payment/session/store/storage.rs
+++ b/crates/tempo-common/src/payment/session/store/storage.rs
@@ -118,6 +118,15 @@ fn open_db_at(path: &Path) -> ChannelStoreResult<rusqlite::Connection> {
         Err(e) => return Err(store_error("migrate channels schema", e)),
     }
 
+    // Migration: add server_spent column for existing databases.
+    match conn
+        .execute_batch("ALTER TABLE channels ADD COLUMN server_spent TEXT NOT NULL DEFAULT '0';")
+    {
+        Ok(()) => {}
+        Err(e) if e.to_string().contains("duplicate column name") => {}
+        Err(e) => return Err(store_error("migrate channels schema (server_spent)", e)),
+    }
+
     Ok(conn)
 }
 
@@ -207,6 +216,7 @@ fn map_channel_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ChannelRecord> {
         grace_ready_at: decode_u64_column(row, 17, "grace_ready_at")?,
         created_at: decode_u64_column(row, 18, "created_at")?,
         last_used_at: decode_u64_column(row, 19, "last_used_at")?,
+        server_spent: decode_u128_column(row, 20, "server_spent")?,
     };
 
     if !record.normalize_persisted_identity() {
@@ -247,8 +257,9 @@ fn save_channel_in_conn(
             channel_id, version, origin, request_url, chain_id,
             escrow_contract, token, payee, payer, authorized_signer,
             salt, deposit, cumulative_amount, accepted_cumulative, challenge_echo,
-            state, close_requested_at, grace_ready_at, created_at, last_used_at
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)
+            state, close_requested_at, grace_ready_at, created_at, last_used_at,
+            server_spent
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)
         ON CONFLICT(channel_id) DO UPDATE SET
             version = excluded.version,
             origin = excluded.origin,
@@ -283,7 +294,8 @@ fn save_channel_in_conn(
             close_requested_at = excluded.close_requested_at,
             grace_ready_at = excluded.grace_ready_at,
             created_at = channels.created_at,
-            last_used_at = excluded.last_used_at",
+            last_used_at = excluded.last_used_at,
+            server_spent = excluded.server_spent",
         params![
             record.channel_id_hex(),
             record.version,
@@ -305,6 +317,7 @@ fn save_channel_in_conn(
             grace_ready_at,
             created_at,
             last_used_at,
+            record.server_spent.to_string(),
         ],
     )
     .map_err(|err| store_error("save channel", err))?;
@@ -320,7 +333,8 @@ fn load_channel_in_conn(
             "SELECT version, origin, request_url, chain_id,
                     escrow_contract, token, payee, payer, authorized_signer,
                     salt, channel_id, deposit, cumulative_amount, accepted_cumulative,
-                    challenge_echo, state, close_requested_at, grace_ready_at, created_at, last_used_at
+                    challenge_echo, state, close_requested_at, grace_ready_at, created_at, last_used_at,
+                    server_spent
              FROM channels WHERE LOWER(channel_id) = LOWER(?1)",
         )
         .map_err(|err| store_error("prepare channel load query", err))?;
@@ -352,7 +366,8 @@ fn find_reusable_channel_in_conn(
             "SELECT version, origin, request_url, chain_id,
                     escrow_contract, token, payee, payer, authorized_signer,
                     salt, channel_id, deposit, cumulative_amount, accepted_cumulative,
-                    challenge_echo, state, close_requested_at, grace_ready_at, created_at, last_used_at
+                    challenge_echo, state, close_requested_at, grace_ready_at, created_at, last_used_at,
+                    server_spent
              FROM channels
              WHERE origin = ?1 AND payer = ?2 AND escrow_contract = ?3
                AND token = ?4 AND payee = ?5 AND chain_id = ?6
@@ -445,7 +460,8 @@ pub fn load_channels_by_origin(origin: &str) -> ChannelStoreResult<Vec<ChannelRe
             "SELECT version, origin, request_url, chain_id,
                     escrow_contract, token, payee, payer, authorized_signer,
                     salt, channel_id, deposit, cumulative_amount, accepted_cumulative,
-                    challenge_echo, state, close_requested_at, grace_ready_at, created_at, last_used_at
+                    challenge_echo, state, close_requested_at, grace_ready_at, created_at, last_used_at,
+                    server_spent
              FROM channels WHERE origin = ?1 ORDER BY last_used_at DESC",
         )
         .map_err(|err| store_error("prepare channels load by origin query", err))?;
@@ -507,7 +523,8 @@ pub fn list_channels() -> ChannelStoreResult<Vec<ChannelRecord>> {
             "SELECT version, origin, request_url, chain_id,
                     escrow_contract, token, payee, payer, authorized_signer,
                     salt, channel_id, deposit, cumulative_amount, accepted_cumulative,
-                    challenge_echo, state, close_requested_at, grace_ready_at, created_at, last_used_at
+                    challenge_echo, state, close_requested_at, grace_ready_at, created_at, last_used_at,
+                    server_spent
              FROM channels
              WHERE origin <> 'http://127.0.0.1'
              ORDER BY last_used_at DESC",
@@ -591,6 +608,7 @@ mod tests {
             deposit: 1_000,
             cumulative_amount: 10,
             accepted_cumulative: 0,
+            server_spent: 0,
             challenge_echo: "{}".to_string(),
             state,
             close_requested_at: 0,
@@ -610,6 +628,7 @@ mod tests {
         let mut record = sample_record(channel_id, 5, ChannelStatus::Active);
         record.token = "0x00000000000000000000000000000000000000Aa".to_string();
         record.payee = "0x00000000000000000000000000000000000000Bb".to_string();
+        record.server_spent = 37;
         save_channel_in_conn(&conn, &record).unwrap();
 
         let loaded = load_channel_in_conn(&conn, &format!("{channel_id:#x}"))
@@ -621,6 +640,7 @@ mod tests {
         assert_eq!(loaded.token, "0x00000000000000000000000000000000000000aa");
         assert_eq!(loaded.payee, "0x00000000000000000000000000000000000000bb");
         assert_eq!(loaded.payer, "0x0000000000000000000000000000000000000004");
+        assert_eq!(loaded.server_spent, 37);
 
         update_channel_close_state_in_conn(
             &conn,

--- a/crates/tempo-request/src/payment/session/flow.rs
+++ b/crates/tempo-request/src/payment/session/flow.rs
@@ -258,6 +258,9 @@ fn apply_response_receipt(
         Ok(receipt) => {
             state.cumulative_amount = state.cumulative_amount.max(receipt.accepted_cumulative);
             state.accepted_cumulative = state.accepted_cumulative.max(receipt.accepted_cumulative);
+            if let Some(spent) = receipt.server_spent {
+                state.server_spent = spent;
+            }
             Ok(receipt.tx_reference)
         }
         Err(reason) => {
@@ -723,6 +726,7 @@ fn build_ondemand_reuse_record(
         deposit: on_chain.deposit,
         cumulative_amount: on_chain.settled,
         accepted_cumulative: on_chain.settled,
+        server_spent: 0,
         challenge_echo,
         state: session::ChannelStatus::Active,
         close_requested_at: 0,
@@ -1034,6 +1038,7 @@ async fn reuse_stage_execute(
         deposit: reusable.on_chain_deposit,
         cumulative_amount: prev_cumulative + challenge.amount,
         accepted_cumulative: reusable.record.accepted_cumulative,
+        server_spent: reusable.record.server_spent,
     };
 
     let ctx = build_channel_context(
@@ -1209,6 +1214,7 @@ async fn open_stage(
         deposit: deposit.deposit,
         cumulative_amount: initial_cumulative,
         accepted_cumulative: 0,
+        server_spent: 0,
     };
     let salt_hex = format!("{salt:#x}");
 
@@ -1438,6 +1444,7 @@ mod tests {
             deposit: 1_000_000,
             cumulative_amount: 500,
             accepted_cumulative: 0,
+            server_spent: 0,
             challenge_echo: "echo".into(),
             state: ChannelStatus::Active,
             close_requested_at: 0,
@@ -1755,12 +1762,14 @@ mod tests {
             deposit: 100,
             cumulative_amount: 20,
             accepted_cumulative: 0,
+            server_spent: 0,
         };
         let tx = apply_response_receipt(&response, &mut state, "session response").unwrap();
         assert_eq!(
             state.cumulative_amount, 20,
             "cumulative should not decrease"
         );
+        assert_eq!(state.server_spent, 10, "server spent should be captured");
         assert!(tx.is_some(), "tx reference should be extracted");
     }
 
@@ -1774,6 +1783,7 @@ mod tests {
             deposit: 100,
             cumulative_amount: 20,
             accepted_cumulative: 0,
+            server_spent: 0,
         };
         let missing = HttpResponse::for_test(200, b"ok");
         let tx = apply_response_receipt(&missing, &mut state_missing, "session response").unwrap();

--- a/crates/tempo-request/src/payment/session/mod.rs
+++ b/crates/tempo-request/src/payment/session/mod.rs
@@ -28,6 +28,9 @@ pub(super) struct ChannelState {
     pub(super) deposit: u128,
     pub(super) cumulative_amount: u128,
     pub(super) accepted_cumulative: u128,
+    /// Server-reported actual spend from `Payment-Receipt`. Used at close to
+    /// avoid overcharging when the server reconciles below the voucher ceiling.
+    pub(super) server_spent: u128,
 }
 
 /// Shared context for session operations (streaming, closing).

--- a/crates/tempo-request/src/payment/session/persist.rs
+++ b/crates/tempo-request/src/payment/session/persist.rs
@@ -36,6 +36,9 @@ pub(super) fn persist_session(
         // Update existing record
         rec.set_cumulative_amount(state.cumulative_amount);
         rec.set_accepted_cumulative(state.accepted_cumulative);
+        if state.server_spent > 0 {
+            rec.set_server_spent(state.server_spent);
+        }
         rec.deposit = state.deposit;
         rec.challenge_echo = echo_json;
         rec.touch();
@@ -56,6 +59,7 @@ pub(super) fn persist_session(
             deposit: state.deposit,
             cumulative_amount: state.cumulative_amount,
             accepted_cumulative: state.accepted_cumulative,
+            server_spent: state.server_spent,
             challenge_echo: echo_json,
             state: ChannelStatus::Active,
             close_requested_at: 0,

--- a/crates/tempo-request/src/payment/session/receipt.rs
+++ b/crates/tempo-request/src/payment/session/receipt.rs
@@ -8,6 +8,7 @@ use mpp::{
 #[derive(Debug, Clone)]
 pub(super) struct ValidatedSessionReceipt {
     pub(super) accepted_cumulative: u128,
+    pub(super) server_spent: Option<u128>,
     pub(super) tx_reference: Option<String>,
 }
 
@@ -76,12 +77,18 @@ pub(super) fn parse_validated_session_receipt_header(
 
     let accepted_cumulative =
         validate_session_receipt_fields(&session_receipt, expected_channel_id)?;
+    let server_spent = session_receipt
+        .spent
+        .parse::<u128>()
+        .ok()
+        .filter(|&v| v > 0);
     let tx_reference = extract_tx_hash(receipt_header)
         .or_else(|| session_receipt.tx_hash.clone())
         .or(Some(base.reference));
 
     Ok(ValidatedSessionReceipt {
         accepted_cumulative,
+        server_spent,
         tx_reference,
     })
 }

--- a/crates/tempo-request/src/payment/session/streaming.rs
+++ b/crates/tempo-request/src/payment/session/streaming.rs
@@ -561,6 +561,7 @@ fn post_voucher(
         deposit: state.deposit,
         cumulative_amount: state.cumulative_amount,
         accepted_cumulative: state.accepted_cumulative,
+        server_spent: state.server_spent,
     };
 
     let client = client.clone();
@@ -622,6 +623,9 @@ pub(super) async fn stream_sse_response(
                         state.cumulative_amount.max(receipt.accepted_cumulative);
                     state.accepted_cumulative =
                         state.accepted_cumulative.max(receipt.accepted_cumulative);
+                    if let Some(spent) = receipt.server_spent {
+                        state.server_spent = spent;
+                    }
                     persist_session(ctx, state)?;
                 }
                 Err(reason) => {
@@ -855,6 +859,11 @@ pub(super) async fn stream_sse_response(
                                     state.cumulative_amount.max(accepted_cumulative);
                                 state.accepted_cumulative =
                                     state.accepted_cumulative.max(accepted_cumulative);
+                                if let Ok(spent) = receipt.spent.trim().parse::<u128>() {
+                                    if spent > 0 {
+                                        state.server_spent = spent;
+                                    }
+                                }
                                 persist_session(ctx, state)?;
                             }
                             Err(reason) => {
@@ -944,6 +953,7 @@ fn parse_sse_chunk(raw: &str) -> (Option<String>, bool) {
 
 #[cfg(test)]
 mod tests {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
         Arc, Mutex, OnceLock,
@@ -1014,7 +1024,29 @@ mod tests {
             deposit: 100,
             cumulative_amount: 10,
             accepted_cumulative: 0,
+            server_spent: 0,
         }
+    }
+
+    fn encode_session_receipt_header(
+        channel_id: alloy::primitives::B256,
+        accepted_cumulative: u128,
+        spent: u128,
+    ) -> String {
+        let receipt = mpp::protocol::methods::tempo::SessionReceipt {
+            method: "tempo".to_string(),
+            intent: "session".to_string(),
+            status: "success".to_string(),
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+            reference: format!("{channel_id:#x}"),
+            challenge_id: "challenge-123".to_string(),
+            channel_id: format!("{channel_id:#x}"),
+            accepted_cumulative: accepted_cumulative.to_string(),
+            spent: spent.to_string(),
+            units: Some(1),
+            tx_hash: Some(format!("{:#x}", alloy::primitives::B256::from([0x11; 32]))),
+        };
+        URL_SAFE_NO_PAD.encode(serde_json::to_vec(&receipt).unwrap())
     }
 
     async fn spawn_test_server(app: Router) -> (String, tokio::task::JoinHandle<()>) {
@@ -1613,6 +1645,80 @@ mod tests {
             state.cumulative_amount, 10,
             "invalid receipt header should be ignored without mutating cumulative"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stream_sse_response_header_receipt_updates_server_spent() {
+        let channel_id = alloy::primitives::B256::from([0x68; 32]);
+        let receipt_header = encode_session_receipt_header(channel_id, 12, 7);
+
+        let app = Router::new().route(
+            "/stream",
+            get({
+                let receipt_header = receipt_header.clone();
+                move || {
+                    let receipt_header = receipt_header.clone();
+                    async move {
+                        axum::http::Response::builder()
+                            .status(StatusCode::OK)
+                            .header("content-type", "text/event-stream")
+                            .header("payment-receipt", receipt_header)
+                            .body(Body::from(
+                                "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}] }\n\n",
+                            ))
+                            .unwrap()
+                    }
+                }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let url = format!("http://{addr}/stream");
+
+        let signer = test_signer();
+        let echo = test_echo();
+        let did = format!("did:pkh:eip155:4217:{:#x}", signer.from);
+        let http = test_http_client();
+        let reqwest_client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let mut state = test_state(channel_id);
+
+        let ctx = ChannelContext {
+            signer: &signer,
+            payer: signer.from,
+            echo: &echo,
+            did: &did,
+            http: &http,
+            url: &url,
+            rpc_url: "http://127.0.0.1:8545",
+            network_id: tempo_common::network::NetworkId::Tempo,
+            origin: "http://127.0.0.1",
+            top_up_deposit: 100,
+            clamped_deposit: None,
+            fee_payer: false,
+            salt: "0x00".to_string(),
+            payee: "0x0000000000000000000000000000000000000002"
+                .parse()
+                .unwrap(),
+            token: "0x0000000000000000000000000000000000000003"
+                .parse()
+                .unwrap(),
+            reqwest_client: &reqwest_client,
+        };
+
+        let response = reqwest_client.get(&url).send().await.unwrap();
+        let result = stream_sse_response(&ctx, &mut state, response).await;
+
+        server.abort();
+        let _ = server.await;
+
+        assert!(result.is_ok());
+        assert_eq!(state.accepted_cumulative, 12);
+        assert_eq!(state.cumulative_amount, 12);
+        assert_eq!(state.server_spent, 7);
     }
 
     #[serial_test::serial]

--- a/crates/tempo-test/src/fixture.rs
+++ b/crates/tempo-test/src/fixture.rs
@@ -162,6 +162,7 @@ pub fn seed_local_session(temp_dir: &TempDir, origin: &str) {
             deposit           TEXT NOT NULL,
             cumulative_amount TEXT NOT NULL,
             accepted_cumulative TEXT NOT NULL DEFAULT '0',
+            server_spent      TEXT NOT NULL DEFAULT '0',
             challenge_echo    TEXT NOT NULL,
             state             TEXT NOT NULL DEFAULT 'active',
             close_requested_at INTEGER NOT NULL DEFAULT 0,

--- a/crates/tempo-wallet/src/commands/sessions/list.rs
+++ b/crates/tempo-wallet/src/commands/sessions/list.rs
@@ -130,6 +130,7 @@ fn persist_discovered_channel(
         deposit: ch.deposit,
         cumulative_amount: ch.settled,
         accepted_cumulative: ch.settled,
+        server_spent: 0,
         challenge_echo: "{}".to_string(),
         state,
         close_requested_at: ch.close_requested_at,
@@ -168,6 +169,7 @@ mod tests {
             deposit: 1_000_000,
             cumulative_amount: 2_000,
             accepted_cumulative: 0,
+            server_spent: 0,
             challenge_echo: "{}".into(),
             state,
             close_requested_at: if state == ChannelStatus::Closing {


### PR DESCRIPTION
Currently, session close takes a cumulative amount instead of the actual receipt spent amount. This is causing charges higher than what is actually spent. 

This PR changes that to charge what is actually spent when closing a session, with a fallback to the cumulative amount if the spent amount is not present.