### PR TITLE
chore: supply chain hardening

### DIFF
--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -31,7 +31,13 @@ jobs:
         run: |
           set -euo pipefail
           version=1.7.8
-          curl -sSL "https://github.com/rhysd/actionlint/releases/download/v${version}/actionlint_${version}_linux_amd64.tar.gz" -o /tmp/actionlint.tgz
+          expected_sha256="be92c2652ab7b6d08425428797ceabeb16e31a781c07bc388456b4e592f3e36a"
+          curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${version}/actionlint_${version}_linux_amd64.tar.gz" -o /tmp/actionlint.tgz
+          actual_sha256=$(sha256sum /tmp/actionlint.tgz | cut -d' ' -f1)
+          if [ "$actual_sha256" != "$expected_sha256" ]; then
+            echo "::error::actionlint checksum mismatch: expected $expected_sha256, got $actual_sha256"
+            exit 1
+          fi
           tar -xzf /tmp/actionlint.tgz -C /tmp
           sudo mv /tmp/actionlint /usr/local/bin/actionlint
       - name: Run actionlint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rapidhash",
  "ruint",
  "rustc-hash 2.1.2",
@@ -1786,7 +1786,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2299,7 +2299,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2448,7 +2448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3160,7 +3160,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -3851,7 +3851,7 @@ dependencies = [
  "futures-core",
  "hex",
  "hmac",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -3894,7 +3894,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4565,7 +4565,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.11.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -4629,7 +4629,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4646,7 +4646,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
  "rustls 0.23.37",
@@ -4667,7 +4667,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -4713,9 +4713,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4776,7 +4776,7 @@ version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustversion",
 ]
 
@@ -5656,7 +5656,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -5747,7 +5747,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5826,7 +5826,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6014,7 +6014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.9.2",
+ "rand 0.9.4",
  "secp256k1-sys 0.11.0",
 ]
 
@@ -6622,13 +6622,13 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo.git#99cfa9a5ca11b58a04957a59cc4e44c946edb7d7"
+source = "git+https://github.com/tempoxyz/tempo.git?rev=7d809cf350e35c92b420a18672222b710f86f77a#7d809cf350e35c92b420a18672222b710f86f77a"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -6688,7 +6688,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo.git#7d809cf350e35c92b420a18672222b710f86f77a"
+source = "git+https://github.com/tempoxyz/tempo.git?rev=7d809cf350e35c92b420a18672222b710f86f77a#7d809cf350e35c92b420a18672222b710f86f77a"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -6699,7 +6699,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo.git#7d809cf350e35c92b420a18672222b710f86f77a"
+source = "git+https://github.com/tempoxyz/tempo.git?rev=7d809cf350e35c92b420a18672222b710f86f77a#7d809cf350e35c92b420a18672222b710f86f77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7281,7 +7281,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustls 0.23.37",
  "rustls-pki-types",
  "sha1",
@@ -7716,7 +7716,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.11"
 tempfile = "3.27"
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo.git", features = ["serde"] }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo.git", rev = "7d809cf350e35c92b420a18672222b710f86f77a", features = ["serde"] }
 thiserror = "2.0"
 time = "0.3"
 tokio = { version = "1.51", features = ["macros", "rt-multi-thread", "signal"] }
@@ -68,5 +68,5 @@ predicates = "3.1"
 serial_test = "3.2"
 
 [patch.crates-io]
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo.git" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo.git" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo.git", rev = "7d809cf350e35c92b420a18672222b710f86f77a" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo.git", rev = "7d809cf350e35c92b420a18672222b710f86f77a" }


### PR DESCRIPTION
- Add SHA256 checksum verification for actionlint binary download in `workflow-validation.yml` (matching the pattern used for changelogs)
- Pin `tempo-alloy` and `tempo-primitives` git deps to `rev = 7d809cf3` to prevent silent drift on `cargo update`
- Bump `rand` 0.9.2 → 0.9.4 (fixes RUSTSEC-2026-0097)

Prompted by: georgen