### PR TITLE
chore: remove unused futures dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6660,7 +6660,6 @@ dependencies = [
  "clap",
  "colored",
  "dirs",
- "futures",
  "getrandom 0.4.2",
  "hex",
  "hostname",

--- a/crates/tempo-common/Cargo.toml
+++ b/crates/tempo-common/Cargo.toml
@@ -18,7 +18,6 @@ alloy.workspace = true
 clap.workspace = true
 colored.workspace = true
 dirs.workspace = true
-futures.workspace = true
 getrandom.workspace = true
 hex.workspace = true
 hostname.workspace = true


### PR DESCRIPTION
Removes unused `futures` dep from tempo-common — not imported anywhere.

Prompted by: horsefacts