### PR TITLE
attribute wallet spending limit errors

### DIFF
--- a/.changelog/zesty-lions-fix.md
+++ b/.changelog/zesty-lions-fix.md
@@ -1,0 +1,6 @@
+---
+tempo-common: patch
+tempo-wallet: patch
+---
+
+Surface access-key spending limit reverts returned by Tempo RPC as a specific wallet error with guidance to refresh or re-authorize the spending limit.

--- a/crates/tempo-common/src/error.rs
+++ b/crates/tempo-common/src/error.rs
@@ -221,6 +221,10 @@ fn format_http_status_error(operation: &str, status: u16, body: Option<&str>) ->
 #[derive(Error, Debug)]
 pub enum PaymentError {
     #[error(
+        "Access key spending limit exceeded. Run 'tempo wallet refresh' to refresh your spending limit, or run 'tempo wallet login' to re-authorize with a higher limit."
+    )]
+    AccessKeySpendingLimitExceeded,
+    #[error(
         "Spending limit exceeded: limit is {limit} {token}, need {required} {token}. Run 'tempo wallet refresh' to refresh your spending limit."
     )]
     SpendingLimitExceeded {
@@ -471,6 +475,15 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "Spending limit exceeded: limit is 10.00 USDC.e, need 20.00 USDC.e. Run 'tempo wallet refresh' to refresh your spending limit."
+        );
+    }
+
+    #[test]
+    fn test_access_key_spending_limit_exceeded_display() {
+        let err = PaymentError::AccessKeySpendingLimitExceeded;
+        assert_eq!(
+            err.to_string(),
+            "Access key spending limit exceeded. Run 'tempo wallet refresh' to refresh your spending limit, or run 'tempo wallet login' to re-authorize with a higher limit."
         );
     }
 

--- a/crates/tempo-common/src/payment/classify.rs
+++ b/crates/tempo-common/src/payment/classify.rs
@@ -29,6 +29,8 @@ pub const SESSION_PROBLEM_INVALID_SIGNATURE: &str =
 pub const SESSION_PROBLEM_SIGNER_MISMATCH: &str =
     "https://paymentauth.org/problems/session/signer-mismatch";
 
+const SPENDING_LIMIT_EXCEEDED_SELECTOR: &str = "0x8a9e71ea";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SessionProblemType {
     ChannelNotFound,
@@ -115,6 +117,28 @@ pub fn map_mpp_validation_error(
     }
 }
 
+/// Classify a Tempo RPC error display string into a typed CLI error.
+///
+/// This covers wallet-owned transaction paths that submit directly through
+/// Alloy and may only expose raw revert selectors.
+#[must_use]
+pub fn classify_tempo_rpc_error(message: impl AsRef<str>) -> Option<crate::error::TempoError> {
+    let lower = message.as_ref().to_lowercase();
+
+    if lower.contains(SPENDING_LIMIT_EXCEEDED_SELECTOR)
+        || lower.contains("spendinglimitexceeded")
+        || lower.contains("spending limit")
+    {
+        return Some(PaymentError::AccessKeySpendingLimitExceeded.into());
+    }
+
+    if lower.contains("revoked") {
+        return Some(PaymentError::AccessKeyRevoked.into());
+    }
+
+    None
+}
+
 /// Classify an mpp provider error into a `TempoError` with actionable context.
 #[must_use]
 pub fn classify_payment_error(err: mpp::MppError, network: &NetworkId) -> crate::error::TempoError {
@@ -164,8 +188,8 @@ pub fn classify_payment_error(err: mpp::MppError, network: &NetworkId) -> crate:
                 .into()
             }
             TempoClientError::TransactionReverted(msg) => {
-                if msg.contains("revoked") {
-                    PaymentError::AccessKeyRevoked.into()
+                if let Some(err) = classify_tempo_rpc_error(&msg) {
+                    err
                 } else {
                     PaymentError::TransactionReverted(msg).into()
                 }
@@ -404,6 +428,27 @@ mod tests {
         assert!(matches!(
             classify_payment_error(err, &NetworkId::Tempo),
             TempoError::Payment(PaymentError::AccessKeyRevoked)
+        ));
+    }
+
+    #[test]
+    fn test_classify_transaction_reverted_with_spending_limit_selector() {
+        let err = mpp::MppError::Tempo(mpp::client::TempoClientError::TransactionReverted(
+            "execution reverted: 0x8a9e71ea".to_string(),
+        ));
+        assert!(matches!(
+            classify_payment_error(err, &NetworkId::Tempo),
+            TempoError::Payment(PaymentError::AccessKeySpendingLimitExceeded)
+        ));
+    }
+
+    #[test]
+    fn test_classify_tempo_rpc_error_spending_limit_selector() {
+        assert!(matches!(
+            classify_tempo_rpc_error("execution reverted: 0x8a9e71ea"),
+            Some(TempoError::Payment(
+                PaymentError::AccessKeySpendingLimitExceeded
+            ))
         ));
     }
 

--- a/crates/tempo-common/src/payment/session/tx.rs
+++ b/crates/tempo-common/src/payment/session/tx.rs
@@ -138,9 +138,6 @@ pub async fn resolve_and_sign_tx_with_fee_payer(
     let gas_limit = match gas_result {
         Ok(gas) => gas,
         Err(original) if wallet.has_stored_key_authorization() => {
-            if let Some(err) = classify_tx_error(&original) {
-                return Err(err);
-            }
             provisioning_signer =
                 wallet
                     .with_key_authorization()
@@ -172,13 +169,15 @@ pub async fn resolve_and_sign_tx_with_fee_payer(
             tx_builder::estimate_gas(provider, gas_request)
                 .await
                 .map_err(|source| {
-                    classify_tx_error(&source).unwrap_or_else(|| {
-                        KeyError::SigningOperationSource {
-                            operation: "estimate gas",
-                            source: Box::new(original),
-                        }
-                        .into()
-                    })
+                    classify_tx_error(&source)
+                        .or_else(|| classify_tx_error(&original))
+                        .unwrap_or_else(|| {
+                            KeyError::SigningOperationSource {
+                                operation: "estimate gas",
+                                source: Box::new(original),
+                            }
+                            .into()
+                        })
                 })?
         }
         Err(e) => {
@@ -241,9 +240,6 @@ pub async fn submit_tempo_tx(
     match provider.send_raw_transaction(&tx_bytes).await {
         Ok(pending) => Ok(format!("{:#x}", pending.tx_hash())),
         Err(original) if wallet.has_stored_key_authorization() => {
-            if let Some(err) = classify_tx_error(&original) {
-                return Err(err);
-            }
             let provisioning_signer =
                 wallet
                     .with_key_authorization()
@@ -265,13 +261,15 @@ pub async fn submit_tempo_tx(
                 .send_raw_transaction(&retry_bytes)
                 .await
                 .map_err(|source| {
-                    classify_tx_error(&source).unwrap_or_else(|| {
-                        NetworkError::RpcSource {
-                            operation: "broadcast transaction",
-                            source: Box::new(original),
-                        }
-                        .into()
-                    })
+                    classify_tx_error(&source)
+                        .or_else(|| classify_tx_error(&original))
+                        .unwrap_or_else(|| {
+                            NetworkError::RpcSource {
+                                operation: "broadcast transaction",
+                                source: Box::new(original),
+                            }
+                            .into()
+                        })
                 })?;
             Ok(format!("{:#x}", pending.tx_hash()))
         }

--- a/crates/tempo-common/src/payment/session/tx.rs
+++ b/crates/tempo-common/src/payment/session/tx.rs
@@ -20,6 +20,7 @@ use mpp::{
 use crate::{
     error::{KeyError, NetworkError, TempoError},
     keys::Signer,
+    payment::classify::classify_tempo_rpc_error,
 };
 
 type ChannelResult<T> = Result<T, TempoError>;
@@ -61,6 +62,10 @@ fn expiring_valid_before() -> u64 {
         .unwrap_or_default()
         .as_secs()
         + VALID_BEFORE_SECS
+}
+
+fn classify_tx_error(err: &impl std::fmt::Display) -> Option<TempoError> {
+    classify_tempo_rpc_error(err.to_string())
 }
 
 /// Estimate gas, build and sign a Tempo type-0x76 transaction.
@@ -133,6 +138,9 @@ pub async fn resolve_and_sign_tx_with_fee_payer(
     let gas_limit = match gas_result {
         Ok(gas) => gas,
         Err(original) if wallet.has_stored_key_authorization() => {
+            if let Some(err) = classify_tx_error(&original) {
+                return Err(err);
+            }
             provisioning_signer =
                 wallet
                     .with_key_authorization()
@@ -163,17 +171,24 @@ pub async fn resolve_and_sign_tx_with_fee_payer(
 
             tx_builder::estimate_gas(provider, gas_request)
                 .await
-                .map_err(|_| KeyError::SigningOperationSource {
-                    operation: "estimate gas",
-                    source: Box::new(original),
+                .map_err(|source| {
+                    classify_tx_error(&source).unwrap_or_else(|| {
+                        KeyError::SigningOperationSource {
+                            operation: "estimate gas",
+                            source: Box::new(original),
+                        }
+                        .into()
+                    })
                 })?
         }
         Err(e) => {
-            return Err(KeyError::SigningOperationSource {
-                operation: "estimate gas",
-                source: Box::new(e),
-            }
-            .into())
+            return Err(classify_tx_error(&e).unwrap_or_else(|| {
+                KeyError::SigningOperationSource {
+                    operation: "estimate gas",
+                    source: Box::new(e),
+                }
+                .into()
+            }))
         }
     };
 
@@ -226,6 +241,9 @@ pub async fn submit_tempo_tx(
     match provider.send_raw_transaction(&tx_bytes).await {
         Ok(pending) => Ok(format!("{:#x}", pending.tx_hash())),
         Err(original) if wallet.has_stored_key_authorization() => {
+            if let Some(err) = classify_tx_error(&original) {
+                return Err(err);
+            }
             let provisioning_signer =
                 wallet
                     .with_key_authorization()
@@ -246,17 +264,24 @@ pub async fn submit_tempo_tx(
             let pending = provider
                 .send_raw_transaction(&retry_bytes)
                 .await
-                .map_err(|_| NetworkError::RpcSource {
-                    operation: "broadcast transaction",
-                    source: Box::new(original),
+                .map_err(|source| {
+                    classify_tx_error(&source).unwrap_or_else(|| {
+                        NetworkError::RpcSource {
+                            operation: "broadcast transaction",
+                            source: Box::new(original),
+                        }
+                        .into()
+                    })
                 })?;
             Ok(format!("{:#x}", pending.tx_hash()))
         }
-        Err(source) => Err(NetworkError::RpcSource {
-            operation: "broadcast transaction",
-            source: Box::new(source),
-        }
-        .into()),
+        Err(source) => Err(classify_tx_error(&source).unwrap_or_else(|| {
+            NetworkError::RpcSource {
+                operation: "broadcast transaction",
+                source: Box::new(source),
+            }
+            .into()
+        })),
     }
 }
 


### PR DESCRIPTION
## Summary
- classify access-key spending limit reverts from raw Tempo RPC errors
- map selector `0x8a9e71ea` / `SpendingLimitExceeded` into a payment error with a wallet-specific hint
- use the classifier during gas estimation and transaction broadcast before falling back to generic RPC/signing errors