### PR TITLE
fix(login): pass selected network to wallet auth

### DIFF
--- a/.changelog/login-network-selection.md
+++ b/.changelog/login-network-selection.md
@@ -1,0 +1,6 @@
+---
+tempo-common: patch
+tempo-wallet: patch
+---
+
+Pass the selected login network through wallet authentication requests so testnet CLI logins stay on testnet instead of falling back to mainnet browser state.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,17 +60,33 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+    env:
+      TEMPO_LINTS_REF: 0dbe62767b6e15963a652f5476bc0b8ae111d6fc
+      TEMPO_LINTS_PNPM_VERSION: 10.28.1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run Tempo Lints
-        uses: tempoxyz/lints@0dbe62767b6e15963a652f5476bc0b8ae111d6fc
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          language: rust
-          path: "."
-          post-comment: false
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          node-version: "lts/*"
+      - name: Run Tempo Lints
+        run: |
+          set -euo pipefail
+
+          # post-comment: false (emit annotations only; do not write to PRs from this fork-safe job)
+          corepack enable
+          corepack prepare "pnpm@${TEMPO_LINTS_PNPM_VERSION}" --activate
+
+          lints_dir="$RUNNER_TEMP/tempo-lints"
+          git init "$lints_dir"
+          git -C "$lints_dir" remote add origin https://github.com/tempoxyz/lints.git
+          git -C "$lints_dir" fetch --depth 1 origin "$TEMPO_LINTS_REF"
+          git -C "$lints_dir" checkout --detach FETCH_HEAD
+
+          pnpm --dir "$lints_dir" install --frozen-lockfile
+          pnpm --dir "$lints_dir" exec tsx "$lints_dir/bin/tempo-lints.ts" rust "$GITHUB_WORKSPACE" --github-action
 
   typos:
     name: typos

--- a/crates/tempo-common/src/network.rs
+++ b/crates/tempo-common/src/network.rs
@@ -89,6 +89,19 @@ impl NetworkId {
         }
     }
 
+    /// Get the browser-auth network slug.
+    ///
+    /// This is intentionally user-facing (`mainnet` / `testnet`) instead of
+    /// the internal network id (`tempo` / `tempo-moderato`) because the wallet
+    /// web app uses this value to select the login environment.
+    #[must_use]
+    pub const fn auth_network_slug(&self) -> &'static str {
+        match self {
+            Self::Tempo => "mainnet",
+            Self::TempoModerato => "testnet",
+        }
+    }
+
     /// Get the chain ID for this network.
     #[must_use]
     pub const fn chain_id(&self) -> u64 {
@@ -255,6 +268,12 @@ mod tests {
         assert_eq!(NetworkId::Tempo.as_str(), "tempo");
         assert_eq!(NetworkId::TempoModerato.as_str(), "tempo-moderato");
         assert_eq!(NetworkId::Tempo.to_string(), "tempo");
+    }
+
+    #[test]
+    fn test_auth_network_slug() {
+        assert_eq!(NetworkId::Tempo.auth_network_slug(), "mainnet");
+        assert_eq!(NetworkId::TempoModerato.auth_network_slug(), "testnet");
     }
 
     #[test]

--- a/crates/tempo-wallet/src/commands/login.rs
+++ b/crates/tempo-wallet/src/commands/login.rs
@@ -220,10 +220,23 @@ async fn do_login(ctx: &Context, no_browser: bool) -> Result<(), TempoError> {
     let client = reqwest::Client::builder()
         .build()
         .map_err(NetworkError::Reqwest)?;
-    let code = create_device_code(&client, &auth_base_url, &pub_key, &code_challenge).await?;
+    let code = create_device_code(
+        &client,
+        &auth_base_url,
+        &pub_key,
+        &code_challenge,
+        ctx.network,
+    )
+    .await?;
 
     let mut auth_url = parsed_url;
-    auth_url.query_pairs_mut().append_pair("code", &code);
+    set_auth_query_param(&mut auth_url, "network", ctx.network.auth_network_slug());
+    set_auth_query_param(
+        &mut auth_url,
+        "chain_id",
+        &ctx.network.chain_id().to_string(),
+    );
+    set_auth_query_param(&mut auth_url, "code", &code);
     let url_str = auth_url.to_string();
 
     // Always print a manual fallback URL, even in machine output modes.
@@ -235,16 +248,17 @@ async fn do_login(ctx: &Context, no_browser: bool) -> Result<(), TempoError> {
     let browser_launch_status = super::auth::try_open_browser(&url_str, no_browser);
 
     if no_browser {
-        show_remote_login_prompt(&url_str, &code);
+        show_remote_login_prompt(ctx.network, &url_str, &code);
     } else if ctx.output_format == OutputFormat::Text {
-        show_login_prompt(&code);
+        show_login_prompt(ctx.network, &code);
     }
 
     if should_track_callback_window(browser_launch_status) {
         ctx.track_event(analytics::CALLBACK_WINDOW_OPENED);
     }
 
-    let callback = poll_until_authorized(&client, &auth_base_url, &code, &code_verifier).await?;
+    let callback =
+        poll_until_authorized(&client, &auth_base_url, &code, &code_verifier, ctx.network).await?;
 
     ctx.track(
         analytics::CALLBACK_RECEIVED,
@@ -270,16 +284,18 @@ async fn do_login(ctx: &Context, no_browser: bool) -> Result<(), TempoError> {
 }
 
 /// Display the verification code and wait prompt for authentication.
-fn show_login_prompt(code: &str) {
+fn show_login_prompt(network: NetworkId, code: &str) {
     let display_code = format_verification_code(code);
+    eprintln!("Network: {}", network.auth_network_slug().bold());
     eprintln!("Verification code: {}", display_code.bold());
     eprintln!();
     eprintln!("Waiting for authentication...");
 }
 
 /// Display the remote-host handoff prompt for a user who is chatting from another device.
-fn show_remote_login_prompt(auth_url: &str, code: &str) {
-    let prompt = remote_login_prompt(auth_url, code);
+fn show_remote_login_prompt(network: NetworkId, auth_url: &str, code: &str) {
+    let prompt = remote_login_prompt(network, auth_url, code);
+    eprintln!("{}", prompt.network_line);
     eprintln!("{}", prompt.auth_url_line);
     eprintln!("Verification code: {}", prompt.verification_code.bold());
     eprintln!("{}", prompt.continue_line);
@@ -289,14 +305,16 @@ fn show_remote_login_prompt(auth_url: &str, code: &str) {
 }
 
 struct RemoteLoginPrompt {
+    network_line: String,
     auth_url_line: String,
     verification_code: String,
     continue_line: &'static str,
     return_line: &'static str,
 }
 
-fn remote_login_prompt(auth_url: &str, code: &str) -> RemoteLoginPrompt {
+fn remote_login_prompt(network: NetworkId, auth_url: &str, code: &str) -> RemoteLoginPrompt {
     RemoteLoginPrompt {
+        network_line: format!("Network: {}", network.auth_network_slug()),
         auth_url_line: format!("Open this link on your device: {auth_url}"),
         verification_code: format_verification_code(code),
         continue_line: "If the wallet page shows that same code, tap Continue.",
@@ -311,6 +329,21 @@ fn format_verification_code(code: &str) -> String {
     } else {
         code.to_string()
     }
+}
+
+fn set_auth_query_param(url: &mut Url, key: &str, value: &str) {
+    let pairs: Vec<(String, String)> = url
+        .query_pairs()
+        .filter(|(k, _)| k != key)
+        .map(|(k, v)| (k.into_owned(), v.into_owned()))
+        .collect();
+
+    url.set_query(None);
+    let mut query = url.query_pairs_mut();
+    for (k, v) in pairs {
+        query.append_pair(&k, &v);
+    }
+    query.append_pair(key, value);
 }
 
 fn should_track_callback_window(status: BrowserLaunchStatus) -> bool {
@@ -329,6 +362,7 @@ async fn poll_until_authorized(
     base_url: &str,
     code: &str,
     code_verifier: &str,
+    network: NetworkId,
 ) -> Result<AuthCallback, TempoError> {
     let start = Instant::now();
     let timeout = Duration::from_secs(CALLBACK_TIMEOUT_SECS);
@@ -338,7 +372,7 @@ async fn poll_until_authorized(
             return Err(KeyError::LoginExpired.into());
         }
 
-        let resp = poll_device_code(client, base_url, code, code_verifier).await?;
+        let resp = poll_device_code(client, base_url, code, code_verifier, network).await?;
 
         if let Some(err) = &resp.error {
             if err.to_lowercase().contains("expired") {
@@ -438,6 +472,7 @@ async fn create_device_code(
     base_url: &str,
     pub_key: &str,
     code_challenge: &str,
+    network: NetworkId,
 ) -> Result<String, TempoError> {
     let url = format!("{base_url}/cli-auth/device-code");
     let resp = client
@@ -446,6 +481,8 @@ async fn create_device_code(
             "pub_key": pub_key,
             "key_type": "secp256k1",
             "code_challenge": code_challenge,
+            "network": network.auth_network_slug(),
+            "chain_id": network.chain_id(),
         }))
         .send()
         .await
@@ -482,12 +519,15 @@ async fn poll_device_code(
     base_url: &str,
     code: &str,
     code_verifier: &str,
+    network: NetworkId,
 ) -> Result<PollResponse, TempoError> {
     let url = format!("{base_url}/cli-auth/poll/{code}");
     let resp = client
         .post(&url)
         .json(&serde_json::json!({
             "code_verifier": code_verifier,
+            "network": network.auth_network_slug(),
+            "chain_id": network.chain_id(),
         }))
         .send()
         .await
@@ -585,10 +625,12 @@ mod tests {
     #[test]
     fn remote_login_prompt_covers_required_remote_handoff_steps() {
         let prompt = remote_login_prompt(
+            NetworkId::TempoModerato,
             "https://wallet.tempo.xyz/cli-auth?code=ANMGE375",
             "ANMGE375",
         );
 
+        assert_eq!(prompt.network_line, "Network: testnet");
         assert_eq!(
             prompt.auth_url_line,
             "Open this link on your device: https://wallet.tempo.xyz/cli-auth?code=ANMGE375"
@@ -601,5 +643,20 @@ mod tests {
         assert!(prompt.return_line.contains("return here"));
         assert!(prompt.return_line.contains("one more authorization link"));
         assert!(prompt.return_line.contains("this host is ready"));
+    }
+
+    #[test]
+    fn set_auth_query_param_replaces_existing_network() {
+        let mut url = Url::parse("https://wallet.tempo.xyz/cli-auth?network=mainnet&code=OLD")
+            .expect("valid url");
+
+        set_auth_query_param(&mut url, "network", "testnet");
+        set_auth_query_param(&mut url, "chain_id", "42431");
+        set_auth_query_param(&mut url, "code", "ANMGE375");
+
+        assert_eq!(
+            url.as_str(),
+            "https://wallet.tempo.xyz/cli-auth?network=testnet&chain_id=42431&code=ANMGE375"
+        );
     }
 }

--- a/crates/tempo-wallet/tests/remote_flows.rs
+++ b/crates/tempo-wallet/tests/remote_flows.rs
@@ -18,6 +18,8 @@ const BALANCE_OF_SELECTOR: &str = "70a08231";
 struct MockLoginServer {
     base_url: String,
     poll_count: Arc<Mutex<u32>>,
+    device_requests: Arc<Mutex<Vec<serde_json::Value>>>,
+    poll_requests: Arc<Mutex<Vec<serde_json::Value>>>,
     shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
     _handle: tokio::task::JoinHandle<()>,
 }
@@ -28,27 +30,38 @@ impl MockLoginServer {
         let addr = listener.local_addr().unwrap();
         let base_url = format!("http://{}:{}", addr.ip(), addr.port());
         let poll_count = Arc::new(Mutex::new(0u32));
+        let device_requests = Arc::new(Mutex::new(Vec::new()));
+        let poll_requests = Arc::new(Mutex::new(Vec::new()));
 
         let device_code = code.to_string();
+        let device_request_log = device_requests.clone();
         let poll_code = code.to_string();
         let poll_state = poll_count.clone();
+        let poll_request_log = poll_requests.clone();
 
         let app = Router::new()
             .route(
                 "/cli-auth/device-code",
-                post(move || {
+                post(move |Json(body): Json<serde_json::Value>| {
                     let code = device_code.clone();
-                    async move { Json(json!({ "code": code })) }
+                    let device_request_log = device_request_log.clone();
+                    async move {
+                        device_request_log.lock().unwrap().push(body);
+                        Json(json!({ "code": code }))
+                    }
                 }),
             )
             .route(
                 "/cli-auth/poll/{code}",
                 post(
-                    move |axum::extract::Path(path_code): axum::extract::Path<String>| {
+                    move |axum::extract::Path(path_code): axum::extract::Path<String>,
+                          Json(body): Json<serde_json::Value>| {
                         let expected = poll_code.clone();
                         let poll_state = poll_state.clone();
+                        let poll_request_log = poll_request_log.clone();
                         async move {
                             assert_eq!(path_code, expected, "unexpected poll code");
+                            poll_request_log.lock().unwrap().push(body);
                             let mut count = poll_state.lock().unwrap();
                             let response = if *count == 0 {
                                 *count += 1;
@@ -80,6 +93,8 @@ impl MockLoginServer {
         Self {
             base_url,
             poll_count,
+            device_requests,
+            poll_requests,
             shutdown_tx: Some(shutdown_tx),
             _handle: handle,
         }
@@ -198,6 +213,9 @@ fn handle_rpc_request(
 
 fn assert_remote_login_handoff(stderr: &str) {
     assert!(stderr.contains("Auth URL:"), "{stderr}");
+    assert!(stderr.contains("network=testnet"), "{stderr}");
+    assert!(stderr.contains("chain_id=42431"), "{stderr}");
+    assert!(stderr.contains("Network: testnet"), "{stderr}");
     assert!(stderr.contains("Verification code:"), "{stderr}");
     assert!(stderr.contains("Open this link on your device"), "{stderr}");
     assert!(
@@ -210,6 +228,20 @@ fn assert_remote_login_handoff(stderr: &str) {
         "{stderr}"
     );
     assert!(stderr.contains("one more authorization link"), "{stderr}");
+}
+
+fn assert_login_server_saw_testnet(login: &MockLoginServer) {
+    let device_requests = login.device_requests.lock().unwrap();
+    assert_eq!(device_requests.len(), 1);
+    assert_eq!(device_requests[0]["network"], "testnet");
+    assert_eq!(device_requests[0]["chain_id"], 42431);
+
+    let poll_requests = login.poll_requests.lock().unwrap();
+    assert!(!poll_requests.is_empty());
+    for req in poll_requests.iter() {
+        assert_eq!(req["network"], "testnet");
+        assert_eq!(req["chain_id"], 42431);
+    }
 }
 
 fn assert_remote_fund_handoff(stderr: &str) {
@@ -373,6 +405,7 @@ async fn login_no_browser_prints_remote_safe_handoff_copy_and_completes() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Wallet"), "{stdout}");
     assert_eq!(*login.poll_count.lock().unwrap(), 2);
+    assert_login_server_saw_testnet(&login);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -394,6 +427,7 @@ async fn login_no_browser_json_keeps_structured_stdout_and_prints_remote_handoff
     let stdout: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(stdout["ready"], true, "{stdout}");
     assert_eq!(*login.poll_count.lock().unwrap(), 2);
+    assert_login_server_saw_testnet(&login);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -416,6 +450,7 @@ async fn login_no_browser_toon_keeps_structured_stdout_and_prints_remote_handoff
         toon_format::decode_default(String::from_utf8_lossy(&output.stdout).trim()).unwrap();
     assert_eq!(stdout["ready"], true, "{stdout}");
     assert_eq!(*login.poll_count.lock().unwrap(), 2);
+    assert_login_server_saw_testnet(&login);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -433,6 +468,9 @@ async fn login_default_flow_keeps_local_copy_and_does_not_print_remote_handoff_t
     assert!(output.status.success(), "login should succeed: {output:?}");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("Auth URL:"), "{stderr}");
+    assert!(stderr.contains("network=testnet"), "{stderr}");
+    assert!(stderr.contains("chain_id=42431"), "{stderr}");
+    assert!(stderr.contains("Network: testnet"), "{stderr}");
     assert!(stderr.contains("Verification code:"), "{stderr}");
     assert!(
         !stderr.contains("Open this link on your device"),
@@ -442,6 +480,7 @@ async fn login_default_flow_keeps_local_copy_and_does_not_print_remote_handoff_t
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Wallet"), "{stdout}");
     assert_eq!(*login.poll_count.lock().unwrap(), 2);
+    assert_login_server_saw_testnet(&login);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
Carries the selected CLI network through the wallet auth URL, device-code request, and poll request. This makes testnet login explicit for users who already have mainnet wallet state in their browser.