### PR TITLE
ci: gate release publish behind release environment, drop release-build cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,10 +89,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           target: ${{ matrix.build.target }}
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          key: ${{ matrix.build.target }}
-          save-if: false
       - name: Build release binary
         run: cargo build --locked --release --target ${{ matrix.build.target }} -p ${{ env.PACKAGE }}
       - run: strip target/${{ matrix.build.target }}/release/${{ env.PACKAGE }}
@@ -154,6 +150,7 @@ jobs:
 
   publish:
     name: Publish ${{ matrix.package }}
+    environment: release
     permissions:
       contents: write
     needs: [parse-tag, build]


### PR DESCRIPTION
ci: gate release publish behind release environment, drop release-build cache