### PR TITLE
fix(request): redact paid-success analytics URLs

### DIFF
--- a/.changelog/paid-success-analytics-url-redaction.md
+++ b/.changelog/paid-success-analytics-url-redaction.md
@@ -1,0 +1,5 @@
+---
+tempo-request: patch
+---
+
+Redact query parameters from paid-success analytics events so payment flows do not report URL secrets after a 402 challenge succeeds.

--- a/crates/tempo-request/src/query/mod.rs
+++ b/crates/tempo-request/src/query/mod.rs
@@ -208,7 +208,13 @@ pub(crate) async fn run(ctx: &Context, query: QueryArgs) -> Result<(), TempoErro
             status_code,
             response,
         }) => {
-            pay_analytics.track_success(tx_hash, channel_id, &target_url, &method_str, status_code);
+            pay_analytics.track_success(
+                tx_hash,
+                channel_id,
+                &sanitized_url,
+                &method_str,
+                status_code,
+            );
             if let Some(resp) = response {
                 // Display receipt summary for charge responses
                 if !is_session {

--- a/crates/tempo-request/tests/query/payment.rs
+++ b/crates/tempo-request/tests/query/payment.rs
@@ -253,6 +253,48 @@ async fn analytics_tx_hash_is_extracted_hex() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn paid_success_analytics_redacts_url_query_params() {
+    let h = PaymentTestHarness::charge_with_body("paid analytics ok").await;
+    let events_path = h.temp.path().join("paid_events_url_redact.log");
+    let url_with_secrets = h.url("/api?api_key=sk_live_paid_secret&token=paid_bearer_secret");
+
+    let output = test_command(&h.temp)
+        .env("TEMPO_TEST_EVENTS", events_path.to_str().unwrap())
+        .args(["--no-proxy", "--dry-run", &url_with_secrets])
+        .output()
+        .unwrap();
+    assert_success(&output, "paid dry-run request should succeed");
+
+    let events = parse_events_log(&events_path);
+    let names: Vec<&str> = events.iter().map(|(name, _)| name.as_str()).collect();
+    assert!(
+        names.contains(&"payment succeeded"),
+        "missing payment succeeded event: {names:?}"
+    );
+    assert!(
+        names.contains(&"query succeeded"),
+        "missing query succeeded event: {names:?}"
+    );
+
+    for (name, props) in &events {
+        if let Some(url) = props.get("url").and_then(|value| value.as_str()) {
+            assert!(
+                !url.contains("sk_live_paid_secret"),
+                "event '{name}' leaks api_key in url: {url}"
+            );
+            assert!(
+                !url.contains("paid_bearer_secret"),
+                "event '{name}' leaks token in url: {url}"
+            );
+            assert!(
+                !url.contains('?'),
+                "event '{name}' has query params in url: {url}"
+            );
+        }
+    }
+}
+
 /// Test the 402 → payment → 200 charge flow with Keychain signing mode.
 ///
 /// Uses a different `wallet_address` than the derived address of the private


### PR DESCRIPTION
Redact the URL used for `query succeeded` analytics after a paid 402 flow succeeds, matching the existing pre-payment analytics behavior. This prevents query parameters such as API keys or tokens from being reported after payment handling.

Tests:
- cargo fmt --check
- cargo test -p tempo-request paid_success_analytics_redacts_url_query_params --test commands
- cargo test -p tempo-request analytics --test commands
